### PR TITLE
Agregar auditoría y vista de uso de IA

### DIFF
--- a/.claude/commands/db-migrate.md
+++ b/.claude/commands/db-migrate.md
@@ -1,0 +1,109 @@
+# DB Migrate — Flujo de migración de base de datos
+
+Ejecuta el flujo de migración de base de datos siguiendo el orden: **Local (Docker) → Neon Dev → Neon Prod**.
+
+## Variables de entorno requeridas (en `server/.env`)
+
+Todas las credenciales y IDs se leen de `server/.env`. Verifica que estas variables estén configuradas antes de ejecutar:
+
+- `DATABASE_URL_LOCAL` — Connection string local (Docker)
+- `DATABASE_URL_DEV` — Connection string Neon Dev
+- `DATABASE_URL_PROD` — Connection string Neon Prod
+- `NEON_PROJECT_ID` — ID del proyecto en Neon
+- `NEON_DATABASE_NAME` — Nombre de la base de datos en Neon
+- `TEST_USER_EMAIL` — Email para login en pruebas
+- `TEST_USER_PASSWORD` — Password para login en pruebas
+
+## Instrucciones
+
+Sigue estos pasos en orden estricto. **Nunca saltes un paso ni apliques cambios en un ambiente remoto sin confirmación explícita del usuario.**
+
+### Paso 1 — Identificar cambios pendientes
+
+1. Lee el schema de Prisma en `server/prisma/schema.prisma`.
+2. Compara con el estado actual de la base de datos local (Docker).
+3. Genera el SQL equivalente a los cambios (ALTER TABLE, CREATE TABLE, ADD COLUMN, etc.).
+4. Muestra al usuario un resumen claro de los cambios que se van a aplicar.
+
+Si el usuario pasa un argumento con la descripción de los cambios, úsalo como contexto. Si no, detecta automáticamente los cambios del schema.
+
+### Paso 2 — Verificar Docker local
+
+1. Ejecuta `docker compose ps` para verificar que el container `cabanero-postgres` está corriendo.
+2. Si no está corriendo, ejecuta `docker compose up -d` y espera a que esté listo.
+3. Lee `DATABASE_URL_LOCAL` de `server/.env` y verifica conectividad ejecutando una query simple.
+
+### Paso 3 — Aplicar en Local (Docker)
+
+1. Ejecuta: `DATABASE_URL="$DATABASE_URL_LOCAL" npx prisma db push --schema server/prisma/schema.prisma` (usando el valor de `DATABASE_URL_LOCAL`).
+2. Verifica que los cambios se aplicaron correctamente ejecutando una query de verificación (ej: `SELECT column_name FROM information_schema.columns WHERE table_name = 'tabla_afectada'`).
+3. Muestra el resultado al usuario.
+
+### Paso 4 — Probar localmente con Playwright
+
+Antes de enviar cambios a cualquier ambiente remoto, verifica que la aplicación funciona correctamente en local con los cambios de DB aplicados.
+
+1. Verifica que el servidor de desarrollo esté corriendo (`http://localhost:5173`). Si no, avisa al usuario que lo inicie.
+2. Navega a `http://localhost:5173/#/login` con `mcp__playwright__browser_navigate`.
+3. Lee `TEST_USER_EMAIL` y `TEST_USER_PASSWORD` de `server/.env` y haz login automático con esas credenciales.
+4. Navega a las secciones afectadas por los cambios de DB y verifica que no hay errores:
+   - Toma snapshots (`mcp__playwright__browser_snapshot`) y screenshots (`mcp__playwright__browser_take_screenshot`).
+   - Revisa la consola del navegador (`mcp__playwright__browser_console_messages`) en busca de errores.
+5. Si las pruebas pasan, muestra evidencia al usuario (screenshots) y continúa.
+6. **Si hay errores, DETENTE.** Reporta los errores y no avances a ambientes remotos hasta que se resuelvan.
+
+### Paso 5 — Confirmar para Neon Dev
+
+1. Muestra al usuario la evidencia de las pruebas locales exitosas.
+2. Muestra un resumen del SQL que se va a aplicar en **Neon Dev**.
+3. Usa `AskUserQuestion` para pedir confirmación explícita antes de continuar.
+4. **No continúes sin confirmación.**
+
+### Paso 6 — Aplicar en Neon Dev
+
+1. Lee `NEON_PROJECT_ID` y `NEON_DATABASE_NAME` de `server/.env`.
+2. Usa la herramienta `mcp__Neon__run_sql` con:
+   - `projectId`: valor de `NEON_PROJECT_ID`
+   - `databaseName`: valor de `NEON_DATABASE_NAME`
+   - SQL: los statements generados en el Paso 1
+   - **No especifiques branchId** (usa el branch por defecto, que es dev)
+3. Verifica que los cambios se aplicaron correctamente.
+4. Muestra el resultado al usuario.
+
+### Paso 7 — Confirmar para Neon Prod
+
+1. Muestra al usuario un resumen de lo que se va a aplicar en **Neon Prod (PRODUCCIÓN)**.
+2. Usa `AskUserQuestion` para pedir confirmación explícita. Incluye una advertencia clara de que esto es **PRODUCCIÓN**.
+3. **No continúes sin confirmación.**
+
+### Paso 8 — Aplicar en Neon Prod
+
+1. Usa la herramienta `mcp__Neon__run_sql` con:
+   - `projectId`: valor de `NEON_PROJECT_ID`
+   - `branchId`: `main`
+   - `databaseName`: valor de `NEON_DATABASE_NAME`
+   - SQL: los mismos statements del Paso 1
+2. Verifica que los cambios se aplicaron correctamente.
+3. Muestra el resultado al usuario.
+
+### Paso 9 — Resumen final
+
+Muestra un resumen con el estado de cada ambiente:
+
+| Paso | Estado | Detalles |
+|------|--------|----------|
+| Local (Docker) | OK/Error | ... |
+| Pruebas Playwright | OK/Error | ... |
+| Neon Dev | OK/Error | ... |
+| Neon Prod | OK/Error | ... |
+
+## Reglas importantes
+
+- **Orden estricto**: Local → Pruebas Playwright → Dev → Prod. Nunca saltes pasos.
+- **Pruebas obligatorias**: No avances a ambientes remotos sin haber verificado que la app funciona localmente con Playwright.
+- **Confirmación obligatoria**: Siempre pide confirmación antes de Dev y antes de Prod.
+- **SQL explícito**: Siempre muestra el SQL que se va a ejecutar antes de aplicarlo.
+- **Verificación**: Después de cada aplicación, verifica que los cambios existen.
+- **Rollback**: Si un paso falla, detente y reporta el error. No intentes continuar con el siguiente ambiente.
+- **Sin datos destructivos**: Si el SQL incluye DROP TABLE, DROP COLUMN, o DELETE, advierte al usuario con énfasis especial.
+- **Sin datos sensibles**: Nunca imprimas credenciales, connection strings ni API keys en el output. Usa las variables de entorno de `server/.env`.

--- a/.claude/commands/test-app.md
+++ b/.claude/commands/test-app.md
@@ -1,0 +1,115 @@
+# Test App — Pruebas E2E con Playwright
+
+Ejecuta pruebas end-to-end de la aplicación usando Playwright MCP. Soporta tres ambientes: **Local**, **Dev (Vercel)** y **Prod (Vercel)**.
+
+## Variables de entorno requeridas (en `server/.env`)
+
+- `TEST_USER_EMAIL` — Email para login en pruebas
+- `TEST_USER_PASSWORD` — Password para login en pruebas
+- `VERCEL_PROJECT_ID` — ID del proyecto en Vercel
+- `VERCEL_TEAM_ID` — ID del equipo en Vercel
+- `VERCEL_PROD_DOMAIN` — Dominio de producción
+
+## Instrucciones
+
+### Paso 1 — Seleccionar ambiente
+
+Usa `AskUserQuestion` para preguntar al usuario en qué ambiente quiere probar:
+
+| Ambiente | URL base | Auth |
+|----------|----------|------|
+| **Local** | `http://localhost:5173` | Login con credenciales |
+| **Dev (Vercel)** | Obtener de Vercel MCP | Login con credenciales |
+| **Prod (Vercel)** | Leer `VERCEL_PROD_DOMAIN` de `server/.env` | Passkeys (manual) |
+
+Si el usuario pasa un argumento (ej: `/test-app local`, `/test-app dev`, `/test-app prod`), úsalo directamente sin preguntar.
+
+### Paso 2 — Obtener URL del ambiente
+
+#### Local
+- URL: `http://localhost:5173`
+- Verifica que Vite esté corriendo. Si no, avisa al usuario que debe iniciar el servidor de desarrollo.
+
+#### Dev (Vercel preview)
+Cada push a cualquier rama genera un deployment en Vercel. La URL puede cambiar entre deployments.
+
+1. Lee `VERCEL_PROJECT_ID` y `VERCEL_TEAM_ID` de `server/.env`.
+2. Usa `mcp__vercel__list_deployments` con esos valores.
+3. Busca el deployment más reciente que esté en estado `READY`. Si el usuario especificó una rama, filtra por esa rama; si no, usa el deployment más reciente de cualquier rama (excluyendo `main`/producción).
+4. Usa `mcp__vercel__get_access_to_vercel_url` con la URL del deployment para obtener una URL con token que bypasea la autenticación de Vercel.
+5. Usa esa URL con token para navegar en Playwright.
+
+#### Prod (Vercel)
+- Lee `VERCEL_PROD_DOMAIN` de `server/.env` y construye la URL: `https://{VERCEL_PROD_DOMAIN}`
+- **IMPORTANTE**: En producción la autenticación es con passkeys. No puedes hacer login automático.
+- Navega a la URL y pide al usuario que se autentique manualmente con passkeys.
+- Usa `mcp__playwright__browser_snapshot` para verificar que el usuario completó el login.
+
+### Paso 3 — Autenticación
+
+#### Local y Dev — Login automático
+1. Lee `TEST_USER_EMAIL` y `TEST_USER_PASSWORD` de `server/.env`.
+2. Navega a `{BASE_URL}/#/login` usando `mcp__playwright__browser_navigate`.
+3. Espera a que cargue la página con `mcp__playwright__browser_snapshot`.
+4. Llena el formulario de login con `mcp__playwright__browser_fill_form` usando las credenciales leídas.
+5. Haz click en el botón de login con `mcp__playwright__browser_click`.
+6. Espera la redirección al dashboard con `mcp__playwright__browser_wait_for` (busca texto del dashboard o espera unos segundos).
+7. Toma un snapshot para verificar que el login fue exitoso.
+
+#### Prod — Login manual con passkeys
+1. Navega a `{BASE_URL}/#/login`.
+2. Informa al usuario: "Estás en producción. Por favor autentícate con passkeys en el navegador."
+3. Usa `AskUserQuestion` para esperar confirmación del usuario de que completó el login.
+4. Toma un snapshot para verificar que el login fue exitoso.
+
+### Paso 4 — Ejecutar pruebas
+
+Una vez autenticado, ejecuta las pruebas que el usuario solicite. Si no especifica qué probar, haz un smoke test básico:
+
+#### Smoke test por defecto
+1. **Dashboard**: Verifica que el dashboard carga correctamente (snapshot + screenshot).
+2. **Navegación**: Navega a las secciones principales y verifica que cargan:
+   - `/#/venues` — Venues
+   - `/#/reservations` — Reservaciones
+   - `/#/calendar` — Calendario
+   - `/#/analytics` — Analytics
+3. **API health**: Navega a `{BASE_URL}/api/health` o verifica en consola que no hay errores de red.
+
+#### Pruebas específicas
+Si el usuario pide probar algo específico (ej: "prueba el formulario de crear venue"), sigue sus instrucciones usando las herramientas de Playwright:
+- `mcp__playwright__browser_navigate` — Navegar a URLs
+- `mcp__playwright__browser_snapshot` — Capturar estado accesible de la página
+- `mcp__playwright__browser_take_screenshot` — Capturar screenshots visuales
+- `mcp__playwright__browser_click` — Hacer click en elementos
+- `mcp__playwright__browser_fill_form` — Llenar formularios
+- `mcp__playwright__browser_type` — Escribir texto en campos
+- `mcp__playwright__browser_wait_for` — Esperar elementos o texto
+- `mcp__playwright__browser_console_messages` — Ver mensajes de consola
+- `mcp__playwright__browser_network_requests` — Ver requests de red
+- `mcp__playwright__browser_select_option` — Seleccionar opciones en dropdowns
+- `mcp__playwright__browser_press_key` — Presionar teclas
+- `mcp__playwright__browser_run_code` — Ejecutar código Playwright personalizado
+
+### Paso 5 — Reporte de resultados
+
+Al finalizar las pruebas, presenta un resumen:
+
+| Prueba | Estado | Detalles |
+|--------|--------|----------|
+| Login | PASS/FAIL | ... |
+| Dashboard | PASS/FAIL | ... |
+| ... | ... | ... |
+
+Si hay errores, incluye:
+- Screenshot del error
+- Mensajes de consola relevantes (`mcp__playwright__browser_console_messages`)
+- Network requests fallidos si aplica
+
+## Reglas importantes
+
+- **Sin datos sensibles**: Nunca imprimas credenciales, connection strings ni API keys en el output. Lee siempre de `server/.env`.
+- **Producción** siempre requiere autenticación manual del usuario (passkeys).
+- Si una prueba falla, **no pares**: continúa con las demás y reporta todos los resultados al final.
+- Usa `browser_snapshot` (accesibilidad) para encontrar elementos y `browser_take_screenshot` para evidencia visual.
+- Si Playwright no está instalado, usa `mcp__playwright__browser_install` primero.
+- Al terminar todas las pruebas, cierra el browser con `mcp__playwright__browser_close`.

--- a/.claude/prompts/bold-payment-integration.md
+++ b/.claude/prompts/bold-payment-integration.md
@@ -1,0 +1,132 @@
+# Integración de Pasarela de Pagos Bold
+
+## Contexto del Proyecto
+
+Cabanero es una app de gestión de hospedajes/cabañas en Colombia. Stack:
+- **Frontend**: Vue 3 + CoreUI + Vite, SPA con hash router
+- **Backend**: Express.js (CJS) en `server/`, Prisma ORM
+- **Database**: Neon Postgres (remoto)
+- **Deployment**: Vercel (frontend estático + backend como Serverless Function)
+- **Dominio**: `cabaneroco.vercel.app`
+
+### Flujo actual de pagos
+- Los clientes pagan manualmente por **Nequi** o transferencia bancaria
+- El administrador registra los pagos manualmente en la app (monto, método, referencia, comprobante)
+- Los pagos se almacenan en la tabla `payments` vinculados a `accommodations`
+- La comunicación con clientes es por **WhatsApp** (ya hay botones de WhatsApp en la app)
+
+### Archivos clave
+- `server/index.js` — Todos los endpoints de la API (Express)
+- `server/prisma/schema.prisma` — Esquema de base de datos
+- `src/views/accommodations/AccommodationDetailView.vue` — Detalle del hospedaje (muestra pagos, depósitos, etc.)
+- `src/views/payments/PaymentFormView.vue` — Formulario de registro de pagos
+- `src/components/accommodations/AccommodationForm.vue` — Formulario de hospedaje
+
+## Sobre Bold (Pasarela de Pagos Colombia)
+
+Bold es una pasarela de pagos colombiana. Documentación: https://developers.bold.co/pagos-en-linea/api-integration
+
+### API Bold - Resumen
+
+**Base URL**: `https://integrations.api.bold.co`
+**Auth**: Header `Authorization: x-api-key <API_KEY>`
+
+#### Endpoints:
+
+1. **GET** `/online/link/v1/payment_methods` — Consultar métodos habilitados (CREDIT_CARD, PSE, NEQUI, BOTON_BANCOLOMBIA)
+
+2. **POST** `/online/link/v1` — Crear link de pago
+   - `amount_type`: "CLOSE" (monto fijo) o "OPEN" (monto libre)
+   - `amount`: { currency: "COP", total_amount, taxes, tip_amount }
+   - `reference`: ID único (alfanumérico, max 60 chars)
+   - `description`: Descripción (2-100 chars)
+   - `expiration_date`: Timestamp en nanosegundos Unix
+   - `callback_url`: URL HTTPS de redirección post-pago
+   - `payment_methods`: Array de métodos aceptados
+   - `payer_email`: Email del cliente
+   - Respuesta: `{ payload: { payment_link: "LNK_xxx", url: "https://checkout.bold.co/LNK_xxx" }, errors: [] }`
+
+3. **GET** `/online/link/v1/{payment_link}` — Consultar estado
+   - Estados: ACTIVE, PROCESSING, PAID, REJECTED, CANCELLED, EXPIRED
+   - Incluye: transaction_id, total, payment_method, reference, is_sandbox
+
+#### Webhooks:
+- Bold notifica cambios de estado a un webhook configurado en el panel del comercio
+- Investigar la documentación de webhooks en: https://developers.bold.co
+
+### Consideraciones
+- Bold requiere `callback_url` con HTTPS (Vercel lo cumple)
+- Tiene ambiente sandbox para pruebas
+- Después de integrar, Bold pide certificación
+
+## Tarea
+
+### Fase 1: Investigación (NO escribir código aún)
+
+1. **Leer la documentación completa de Bold** via web:
+   - https://developers.bold.co/pagos-en-linea/api-integration
+   - https://developers.bold.co/pagos-en-linea/api-link-de-pagos
+   - https://developers.bold.co/pagos-en-linea/boton-de-pagos/ambiente-pruebas
+   - Buscar documentación de **webhooks** (payload, verificación de firma, etc.)
+   - Buscar documentación del **botón de pagos** (puede ser alternativa más simple al API)
+
+2. **Leer el código actual** para entender la estructura de pagos:
+   - Modelo `payments` en `server/prisma/schema.prisma`
+   - Endpoints de payments en `server/index.js` (buscar `/api/payments`)
+   - `AccommodationDetailView.vue` — sección de pagos
+   - `PaymentFormView.vue` — formulario actual
+
+3. **Definir el flujo propuesto**:
+   - ¿Link de pago o botón de pagos embebido?
+   - ¿Cómo manejar pagos parciales? (el cliente puede abonar, no siempre paga el total)
+   - ¿Webhook o polling para confirmar pago?
+   - ¿Cómo vincular el pago Bold con el registro en la tabla `payments`?
+
+### Fase 2: Plan de implementación
+
+Crear un plan detallado que incluya:
+
+1. **Cambios en base de datos**:
+   - Campos nuevos en `payments` (payment_link_id, transaction_id, bold_status, etc.)
+   - O tabla nueva para transacciones Bold
+
+2. **Endpoints backend nuevos**:
+   - Crear link de pago Bold
+   - Webhook receiver para notificaciones de Bold
+   - Consultar estado de pago Bold
+
+3. **Cambios frontend**:
+   - Botón "Enviar link de pago" en detalle del hospedaje
+   - Mostrar estado del pago Bold
+   - Página de callback post-pago (¿o redirigir al detalle?)
+
+4. **Configuración**:
+   - Variables de entorno necesarias (BOLD_API_KEY, BOLD_SECRET_KEY, etc.)
+   - Configuración de webhook en Bold
+
+5. **Testing**:
+   - Usar sandbox de Bold
+   - Probar flujo completo: crear link → pagar → webhook → verificar en app
+
+### Fase 3: Implementación
+
+Implementar según el plan aprobado. Seguir las convenciones del proyecto:
+- Backend en CJS (require/module.exports)
+- Frontend en Vue 3 Composition API con `<script setup>`
+- CoreUI para componentes UI
+- Prisma para queries de DB
+- Variables de entorno en Vercel
+
+## Variables de entorno a agregar en Vercel
+```
+BOLD_API_KEY=<api_key_de_bold>
+BOLD_WEBHOOK_SECRET=<si_aplica>
+BOLD_SANDBOX=true  # cambiar a false en producción
+```
+
+## Notas importantes
+- La app ya maneja pagos manuales. Bold NO reemplaza esto — es una opción adicional
+- Los clientes actuales pagan por Nequi/transferencia. Bold permitiría pagar por link
+- El link de pago se puede enviar por WhatsApp (flujo natural para los usuarios)
+- Considerar que Bold cobra comisión por transacción — investigar tarifas
+- El `reference` del link Bold debe ser trazable al payment/accommodation en Cabanero

--- a/.claude/prompts/glassmorphism-migration.md
+++ b/.claude/prompts/glassmorphism-migration.md
@@ -1,0 +1,350 @@
+# Plan: Migración Glassmorphism Global — Light + Dark Mode
+
+## Contexto
+
+La app tiene un estilo Glassmorphism que funciona correctamente en la página de Login (con soporte light y dark), pero en el resto de la app (DefaultLayout) los estilos son **dark-only**. Han habido 3 intentos fallidos de migrar. El análisis detallado reveló las causas raíz:
+
+1. **Intento 1**: Aplicó estilos dark en `body`/`:root` sin scoping, rompió Login. Usó `!important` en cascada. Revertido completamente.
+2. **Intento 2**: Intentó usar `var(--cabania-*)` en `<style scoped>` de Login pero las variables de `:root` no se resolvían a tiempo (Vite CSS ordering). Revertido.
+3. **Intento 3** (actual): Scoped a `.wrapper` — funciona para dark mode pero **no tiene light mode**. El `:root` define tokens con valores dark, `body` los aplica globalmente. No hay alternativa light.
+
+**Insight clave**: El Login.vue tiene el patrón correcto — define light defaults y dark overrides en CSS vars locales. La migración global debe replicar esto usando `[data-coreui-theme="dark"]` (el selector que CoreUI ya maneja).
+
+## Arquitectura de Temas CoreUI
+
+### Cómo funciona el tema en CoreUI
+- `useColorModes('coreui-free-vue-admin-template-theme')` composable de `@coreui/vue`
+- Almacena preferencia en `localStorage['coreui-free-vue-admin-template-theme']`
+- Setea atributo `data-coreui-theme` en `<html>` en runtime (light, dark, o auto)
+- `coreui.min.css` tiene reglas `[data-coreui-theme="dark"]` para dark mode
+- En SCSS: `@include color-mode(dark) { ... }` genera `[data-coreui-theme=dark]` selectors
+
+### Archivos clave del tema
+- `src/components/AppHeader.vue` — Único control point del tema (dropdown light/dark/auto)
+- `src/main.js` — Importa `coreui.min.css` + `@/assets/style.css`
+- `src/styles/style.scss` — **520 líneas** de estilos custom + Glassmorphism
+- `src/views/pages/Login.vue` — Implementación dual-theme independiente (scoped CSS)
+- `src/stores/theme.js` — Pinia store **NO USADO** (artifact muerto)
+- `src/components/AppSidebar.vue` — Tiene `colorScheme="dark"` hardcoded
+
+### Flujo del layout
+```
+App.vue → router-view
+  ├── Login.vue (ruta /login — SIN .wrapper, fuera de DefaultLayout)
+  └── DefaultLayout.vue
+       ├── AppSidebar (.sidebar)
+       └── div.wrapper
+            ├── TrialBanner
+            ├── AppHeader (.header)
+            ├── div.body > CContainer > router-view (vistas de la app)
+            └── AppFooter (.footer)
+```
+
+## Principios de la Migración
+
+1. **`:root`** define tokens **light** (nuevos defaults) — Glassmorphism sobre fondo claro
+2. **`[data-coreui-theme="dark"]`** redefine tokens a valores dark (los actuales)
+3. **`.wrapper`** scoping se mantiene — Login nunca se afecta
+4. **Modals/dropdowns** usan variables (no hardcoded `#0f172a`)
+5. **Sidebar** se hace theme-aware (remove `colorScheme="dark"`)
+6. **Cero `!important` nuevos** — solo mantener los 6 existentes donde CoreUI utilities lo requieren
+
+## Archivos a Modificar
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/styles/style.scss` | Refactorizar tokens `:root` + dark overrides, fix hardcoded colors |
+| `src/components/AppSidebar.vue` | Remover `colorScheme="dark"` (1 línea) |
+
+**NO se toca**: Login.vue, DefaultLayout.vue, AppHeader.vue, main.js, vistas individuales.
+
+## Paso 1: Bifurcar tokens `:root` en light + dark
+
+### Tokens Light (nuevos defaults en `:root`)
+
+Reemplazar las líneas 13-58 de `style.scss`:
+
+```scss
+:root {
+  // Backgrounds
+  --cabania-bg: #f1f5f9;
+  --cabania-card-bg: rgba(255, 255, 255, 0.65);
+  --cabania-input-bg: rgba(255, 255, 255, 0.6);
+  --cabania-hover-bg: rgba(0, 0, 0, 0.03);
+  --cabania-active-bg: rgba(16, 185, 129, 0.08);
+  --cabania-surface-bg: rgba(255, 255, 255, 0.85);  // NEW: modals, dropdowns
+
+  // Borders
+  --cabania-border: rgba(0, 0, 0, 0.08);
+  --cabania-border-subtle: rgba(0, 0, 0, 0.05);
+  --cabania-active-border: rgba(16, 185, 129, 0.15);
+  --cabania-focus-border: rgba(14, 165, 233, 0.4);
+
+  // Text
+  --cabania-text: #0f172a;
+  --cabania-text-secondary: #475569;
+  --cabania-text-muted: #64748b;
+  --cabania-text-dim: #94a3b8;
+
+  // Accent colors (ligeramente más oscuros para fondo claro)
+  --cabania-emerald: #059669;
+  --cabania-sky: #0284c7;
+  --cabania-gradient: linear-gradient(135deg, #10b981, #0ea5e9);
+
+  // Accent with opacity
+  --cabania-emerald-glow: rgba(16, 185, 129, 0.1);
+  --cabania-emerald-glow-subtle: rgba(16, 185, 129, 0.05);
+  --cabania-sky-glow: rgba(14, 165, 233, 0.1);
+
+  // Danger
+  --cabania-danger-border: rgba(239, 68, 68, 0.2);
+  --cabania-danger-bg: rgba(239, 68, 68, 0.06);
+  --cabania-danger-text: #dc2626;
+
+  // Shadows (lighter for light bg)
+  --cabania-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.08);
+  --cabania-shadow-sm: 0 2px 8px rgba(16, 185, 129, 0.1);
+  --cabania-shadow-md: 0 4px 12px rgba(16, 185, 129, 0.1);
+
+  // Radii (sin cambio)
+  --cabania-radius-sm: 0.5rem;
+  --cabania-radius: 0.75rem;
+  --cabania-radius-lg: 1rem;
+  --cabania-radius-xl: 1.5rem;
+}
+```
+
+### Tokens Dark (agregar NUEVO bloque después del `:root`)
+
+Agregar inmediatamente después del bloque `:root` usando CoreUI's mixin:
+
+```scss
+@include color-mode(dark) {
+  :root {
+    --cabania-bg: #020617;
+    --cabania-card-bg: rgba(255, 255, 255, 0.05);
+    --cabania-input-bg: rgba(2, 6, 23, 0.4);
+    --cabania-hover-bg: rgba(255, 255, 255, 0.05);
+    --cabania-active-bg: rgba(16, 185, 129, 0.15);
+    --cabania-surface-bg: #0f172a;
+
+    --cabania-border: rgba(255, 255, 255, 0.15);
+    --cabania-border-subtle: rgba(255, 255, 255, 0.1);
+    --cabania-active-border: rgba(16, 185, 129, 0.25);
+    --cabania-focus-border: rgba(14, 165, 233, 0.5);
+
+    --cabania-text: #f1f5f9;
+    --cabania-text-secondary: #cbd5e1;
+    --cabania-text-muted: #94a3b8;
+    --cabania-text-dim: #64748b;
+
+    --cabania-emerald: #10b981;
+    --cabania-sky: #0ea5e9;
+
+    --cabania-emerald-glow: rgba(16, 185, 129, 0.2);
+    --cabania-emerald-glow-subtle: rgba(16, 185, 129, 0.1);
+    --cabania-sky-glow: rgba(14, 165, 233, 0.2);
+
+    --cabania-danger-border: rgba(239, 68, 68, 0.3);
+    --cabania-danger-bg: rgba(239, 68, 68, 0.1);
+    --cabania-danger-text: #fca5a5;
+
+    --cabania-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4);
+    --cabania-shadow-sm: 0 2px 8px rgba(16, 185, 129, 0.15);
+    --cabania-shadow-md: 0 4px 12px rgba(16, 185, 129, 0.15);
+  }
+}
+```
+
+## Paso 2: Fix hardcoded dark colors en overrides
+
+Reemplazar los 2 valores `#0f172a` hardcoded en los bloques de modals y dropdowns:
+
+```scss
+// Antes (línea ~279):
+.modal-content { background-color: #0f172a; ... }
+
+// Después:
+.modal-content { background-color: var(--cabania-surface-bg); ... }
+
+// Antes (línea ~264):
+.wrapper .dropdown-menu { --cui-dropdown-bg: #0f172a; ... }
+
+// Después:
+.wrapper .dropdown-menu { --cui-dropdown-bg: var(--cabania-surface-bg); ... }
+```
+
+## Paso 3: Eliminar bloque `@include color-mode(dark)` viejo (L115-123)
+
+El bloque actual en líneas 115-123 overridea body bg con `var(--cui-dark-bg-subtle)`. Esto conflicta con nuestro sistema. **Eliminarlo completo**:
+
+```scss
+// ELIMINAR este bloque completo (líneas 115-123 de style.scss):
+@include color-mode(dark) {
+  body { background-color: var(--cui-dark-bg-subtle); }
+  .footer { --cui-footer-bg: var(--cui-body-bg); }
+}
+```
+
+El footer dark ya está cubierto por `.wrapper .footer` (L194-198). Y el body dark bg viene de nuestro nuevo token `--cabania-bg` que cambia a `#020617` en dark mode.
+
+## Paso 4: Verificar `body` y `.wrapper` rules (sin cambio)
+
+Las reglas en líneas 60-72 ya consumen `var(--cabania-bg)` y `var(--cabania-text)`, así que automáticamente cambiarán con el tema. **No necesitan cambio**:
+
+```scss
+// Estas líneas NO se tocan:
+body {
+  background-color: var(--cabania-bg);  // → #f1f5f9 light, #020617 dark
+  color: var(--cabania-text);           // → #0f172a light, #f1f5f9 dark
+}
+
+.wrapper {
+  // ...
+  background-color: var(--cabania-bg);
+  color: var(--cabania-text);
+}
+```
+
+## Paso 5: Hacer sidebar theme-aware
+
+**`src/components/AppSidebar.vue`** línea 15:
+
+```vue
+<!-- Antes: -->
+<CSidebar class="border-end" colorScheme="dark" position="fixed" ...>
+
+<!-- Después: -->
+<CSidebar class="border-end" position="fixed" ...>
+```
+
+CoreUI's `colorScheme="dark"` fuerza `data-coreui-color-scheme="dark"` en el sidebar, lo cual override las variables CSS. Al quitarlo, el sidebar respeta las variables `--cabania-*` que ya definimos en `.sidebar` (L360-396 de style.scss).
+
+Las reglas existentes de `.sidebar` consumen `var(--cabania-*)` → automáticamente se adaptan cuando los tokens cambian entre light/dark.
+
+## Paso 6: Glass Stat Cards (Dashboard + Analytics)
+
+Las 13 stat cards usan `bg-success text-white`, `bg-primary text-white`, etc. con fondos sólidos. Se reemplazan con glassmorphism con tinte de color.
+
+### 6a. Nuevas clases SCSS al final de `style.scss`
+
+```scss
+// --- Glass stat cards ---
+.wrapper .cabania-glass {
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid;
+  transition: background-color 0.3s, border-color 0.3s, color 0.3s;
+
+  .cabania-glass__label { opacity: 0.6; }
+
+  // Color variants (light mode defaults)
+  &--success  { background-color: rgba(16, 185, 129, 0.08) !important;  border-color: rgba(16, 185, 129, 0.2);  color: #059669; }
+  &--danger   { background-color: rgba(239, 68, 68, 0.08) !important;   border-color: rgba(239, 68, 68, 0.2);   color: #dc2626; }
+  &--warning  { background-color: rgba(245, 158, 11, 0.08) !important;  border-color: rgba(245, 158, 11, 0.2);  color: #d97706; }
+  &--primary  { background-color: rgba(99, 102, 241, 0.08) !important;  border-color: rgba(99, 102, 241, 0.2);  color: #4f46e5; }
+  &--info     { background-color: rgba(14, 165, 233, 0.08) !important;  border-color: rgba(14, 165, 233, 0.2);  color: #0284c7; }
+  &--secondary { background-color: rgba(100, 116, 139, 0.08) !important; border-color: rgba(100, 116, 139, 0.2); color: #475569; }
+  &--dark     { background-color: rgba(30, 41, 59, 0.08) !important;    border-color: rgba(30, 41, 59, 0.2);    color: #1e293b; }
+}
+
+@include color-mode(dark) {
+  .wrapper .cabania-glass {
+    &--success  { background-color: rgba(16, 185, 129, 0.15) !important;  border-color: rgba(16, 185, 129, 0.25);  color: #10b981; }
+    &--danger   { background-color: rgba(239, 68, 68, 0.15) !important;   border-color: rgba(239, 68, 68, 0.25);   color: #f87171; }
+    &--warning  { background-color: rgba(245, 158, 11, 0.15) !important;  border-color: rgba(245, 158, 11, 0.25);  color: #fbbf24; }
+    &--primary  { background-color: rgba(99, 102, 241, 0.15) !important;  border-color: rgba(99, 102, 241, 0.25);  color: #818cf8; }
+    &--info     { background-color: rgba(14, 165, 233, 0.15) !important;  border-color: rgba(14, 165, 233, 0.25);  color: #38bdf8; }
+    &--secondary { background-color: rgba(100, 116, 139, 0.15) !important; border-color: rgba(100, 116, 139, 0.25); color: #94a3b8; }
+    &--dark     { background-color: rgba(30, 41, 59, 0.15) !important;    border-color: rgba(30, 41, 59, 0.25);    color: #cbd5e1; }
+  }
+}
+```
+
+### 6b. Cambios en templates
+
+**Dashboard.vue** — 9 cards:
+- `text-white bg-secondary` → `cabania-glass cabania-glass--secondary`
+- `text-white bg-dark` → `cabania-glass cabania-glass--dark`
+- `text-white bg-info` → `cabania-glass cabania-glass--info` (×2)
+- `text-white bg-primary` → `cabania-glass cabania-glass--primary` (×2)
+- `text-white bg-warning` → `cabania-glass cabania-glass--warning`
+- `text-white bg-success` → `cabania-glass cabania-glass--success` (×2)
+- Todos los `text-white-50` → `cabania-glass__label`
+
+**AnalyticsView.vue** — 4 cards:
+- `text-white bg-success` → `cabania-glass cabania-glass--success`
+- `text-white bg-danger` → `cabania-glass cabania-glass--danger`
+- `text-white bg-warning` → `cabania-glass cabania-glass--warning`
+- `text-white bg-primary` → `cabania-glass cabania-glass--primary`
+- Todos los `text-white-50` → `cabania-glass__label`
+
+## Paso 7 (opcional): Sidebar light mode refinement
+
+Si el sidebar en light mode no se ve bien, agregar `backdrop-filter: blur(8px)` al `.sidebar`. Se evalúa durante testing.
+
+## Resumen de todos los cambios
+
+### `style.scss`
+
+| Sección | Líneas | Acción |
+|---------|--------|--------|
+| `:root` tokens | 13-58 | Reemplazar: dark values → light values + `--cabania-surface-bg` |
+| (nuevo bloque) | después de `:root` | Agregar `@include color-mode(dark) { :root { ... } }` |
+| `@include color-mode(dark)` viejo | 115-123 | **ELIMINAR** completo |
+| `.wrapper .dropdown-menu` bg | ~264 | `#0f172a` → `var(--cabania-surface-bg)` |
+| `.modal-content` bg | ~279 | `#0f172a` → `var(--cabania-surface-bg)` |
+| (nuevo al final) | — | `.cabania-glass` + variantes light/dark |
+
+### Otros archivos
+
+| Archivo | Cambio |
+|---------|--------|
+| `AppSidebar.vue` L15 | Remover `colorScheme="dark"` |
+| `Dashboard.vue` | 9 cards: clases → `cabania-glass--*` + labels |
+| `AnalyticsView.vue` | 4 cards: clases → `cabania-glass--*` + labels |
+
+**Total**: ~120 líneas en style.scss + 1 línea AppSidebar + ~26 cambios de clase en templates.
+
+## ¿Por qué esto NO va a fallar?
+
+1. **Login está aislada**: Scoped styles + `.wrapper` scoping = Login nunca se afecta
+2. **CoreUI no se pelea**: Usamos su propio `@include color-mode(dark)` mixin, no selectores custom
+3. **Cambio mínimo**: Solo movemos tokens de lugar y agregamos light defaults. Las ~300 líneas de overrides de `.wrapper` NO se tocan
+4. **Variables se resuelven en cascade**: `:root` → `[data-coreui-theme=dark] :root` override. Todos los `var()` consumen automáticamente el valor correcto
+5. **Sin `!important` nuevos**: Los 6 existentes se mantienen, no se agregan más
+6. **Incremental**: Se puede testear después de cada paso
+
+## Diferencia con los intentos fallidos
+
+| Aspecto | Intento 1 (fallido) | Intento 2 (fallido) | Intento 3 (parcial) | Este plan |
+|---------|--------------------|--------------------|--------------------|-----------|
+| Scope de overrides | `body`, bare selectors | `:root` solo | `.wrapper` scoped | `.wrapper` scoped |
+| Login isolation | Ninguna | var() en scoped CSS falló | Login fuera de .wrapper | Login fuera de .wrapper |
+| CoreUI integration | Peleó con !important | N/A | Usó --cui-* variables | Usa --cui-* + color-mode() mixin |
+| Light/dark support | Solo dark | Solo dark tokens | Solo dark | **Ambos** |
+| !important count | 12+ | 0 | ~6 | ~6 (sin nuevos) |
+
+## Verificación
+
+1. **Build local**: `npm run dev` — verificar que compila sin errores SCSS
+2. **Light mode**: Navegar por Dashboard, formularios, tablas — verificar glassmorphism light
+3. **Dark mode**: Toggle a dark — verificar que se mantiene el look actual exacto
+4. **Login**: Verificar que Login light y dark siguen exactamente igual (no se tocó)
+5. **Sidebar**: Verificar que cambia correctamente entre light y dark
+6. **Modals**: Abrir un modal en ambos temas — verificar backgrounds
+7. **Theme toggle**: Alternar rápido entre light/dark/auto — sin parpadeo, transición suave
+
+## Componentes CoreUI usados en la app (referencia)
+
+88 tipos de componentes únicos usados. Los más relevantes para tema:
+- CCard, CTable, CForm*, CModal, CDropdown, CNav, CPagination, CBadge
+- CWidgetStats*, CChart* (charts usan colores hardcoded en JS — fuera de scope)
+- CSidebar (el único que necesita cambio de prop)
+
+## Archivos con scoped styles (34 archivos)
+
+Ninguno debería necesitar cambios porque:
+- Usan clases CoreUI que se adaptan via CSS variables
+- Los pocos que tienen colores inline usan `var(--cui-*)` correctamente
+- Login.vue tiene su propio sistema aislado `--cl-*`

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,2 @@
-# Mapbox credentials
+# Mapbox credentials (Vite lee del root)
 VITE_MAPBOX_ACCESS_TOKEN=your-mapbox-access-token
-
-# Other environment variables can be added here

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,8 @@ __screenshots__/
 .playwright-mcp/
 
 # Claude / AI
-.claude/
-!.claude/commands/
+.claude/settings.local.json
+.claude/skills/
 .agents/
 
 # Misc

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ __screenshots__/
 
 # Claude / AI
 .claude/
+!.claude/commands/
 .agents/
 
 # Misc

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,27 +1,67 @@
-# Base de datos (Neon)
-DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+# ============================================
+# Base de datos
+# ============================================
+# La activa (descomenta la que uses)
+DATABASE_URL=postgresql://user:password@localhost:5432/neondb
 
+# URLs por ambiente (para skills de migración)
+DATABASE_URL_LOCAL=postgresql://user:password@localhost:5432/neondb
+DATABASE_URL_DEV=postgresql://user:password@host-dev.neon.tech/neondb?sslmode=require
+DATABASE_URL_PROD=postgresql://user:password@host-prod.neon.tech/neondb?sslmode=require
+
+# ============================================
 # Sesiones
+# ============================================
 SESSION_SECRET=your-session-secret
 
+# ============================================
 # Mapbox
+# ============================================
 VITE_MAPBOX_ACCESS_TOKEN=your-mapbox-token
 
+# ============================================
 # Cloudinary (Image Storage)
+# ============================================
 CLOUDINARY_CLOUD_NAME=your-cloud-name
 CLOUDINARY_API_KEY=your-api-key
 CLOUDINARY_API_SECRET=your-api-secret
+# Prod: cabanero-dev | Dev: cabanero
 CLOUDINARY_FOLDER_PREFIX=cabanero-dev
 
+# ============================================
 # App
+# ============================================
 APP_ADMIN_SECRET=your-admin-secret
 DEFAULT_PROFILE_CODE=organization:admin
 DEFAULT_SUBSCRIPTION_ID=your-subscription-uuid
 
+# ============================================
 # Puerto
+# ============================================
 PORT=3000
 
+# ============================================
 # API Keys de IA
+# ============================================
 GROK_API_KEY=
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
+
+# ============================================
+# Neon (para skills de migración)
+# ============================================
+NEON_PROJECT_ID=your-neon-project-id
+NEON_DATABASE_NAME=neondb
+
+# ============================================
+# Vercel (para skills de testing)
+# ============================================
+VERCEL_PROJECT_ID=your-vercel-project-id
+VERCEL_TEAM_ID=your-vercel-team-id
+VERCEL_PROD_DOMAIN=your-app-domain.com
+
+# ============================================
+# Testing (credenciales para pruebas E2E)
+# ============================================
+TEST_USER_EMAIL=test@example.com
+TEST_USER_PASSWORD=your-test-password

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -426,17 +426,19 @@ model deposit_evidence {
 }
 
 model llm_providers {
-  id         String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  code       String    @unique @db.VarChar(50)
-  name       String    @db.VarChar(100)
-  api_key    String?
-  base_url   String?
-  model      String?   @db.VarChar(100)
-  is_active  Boolean   @default(true)
-  is_default Boolean   @default(false)
-  config     Json?     @db.Json
-  created_at DateTime  @default(now()) @db.Timestamptz(6)
-  updated_at DateTime? @db.Timestamptz(6)
+  id                    String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  code                  String    @unique @db.VarChar(50)
+  name                  String    @db.VarChar(100)
+  api_key               String?
+  base_url              String?
+  model                 String?   @db.VarChar(100)
+  is_active             Boolean   @default(true)
+  is_default            Boolean   @default(false)
+  config                Json?     @db.Json
+  input_price_per_mtok  Decimal?  @db.Decimal(10, 4)
+  output_price_per_mtok Decimal?  @db.Decimal(10, 4)
+  created_at            DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at            DateTime? @db.Timestamptz(6)
 }
 
 model ai_settings {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -740,6 +740,37 @@ model commission_rules {
   @@index([agent_id, plan_type, sort_order])
 }
 
+// ========================================
+// AI AUDIT LOGS
+// ========================================
+
+model ai_audit_logs {
+  id                  String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  venue_id            String?   @db.Uuid
+  feature             String    @db.VarChar(50)
+  provider_code       String    @db.VarChar(50)
+  model               String    @db.VarChar(100)
+  system_prompt       String?
+  user_prompt         String?
+  response_content    String?
+  input_tokens        Int?
+  output_tokens       Int?
+  response_time_ms    Int?
+  request_size_bytes  Int?
+  response_size_bytes Int?
+  cost_estimate       Decimal?  @db.Decimal
+  user_id             String?   @db.VarChar(255)
+  accommodation_id    String?   @db.Uuid
+  conversation_id     String?   @db.Uuid
+  error               String?
+  metadata            Json?     @db.Json
+  created_at          DateTime  @default(now()) @db.Timestamptz(6)
+
+  @@index([venue_id])
+  @@index([feature])
+  @@index([created_at])
+}
+
 model commission_payments {
   id                String            @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   agent_id          String            @db.Uuid

--- a/server/scripts/seeds/llm-providers.js
+++ b/server/scripts/seeds/llm-providers.js
@@ -1,15 +1,15 @@
 const data = [
-  { code: 'anthropic', name: 'Anthropic Claude', base_url: 'https://api.anthropic.com', model: 'claude-3-haiku-20240307', is_active: true, is_default: false },
-  { code: 'deepseek', name: 'DeepSeek V3', base_url: 'https://api.deepseek.com', model: 'deepseek-chat', is_active: true, is_default: false },
-  { code: 'xai_grok', name: 'Groq', base_url: 'https://api.x.ai/v1', model: 'grok-3-fast', is_active: true, is_default: true },
-  { code: 'openai', name: 'OpenAI', base_url: 'https://api.openai.com/v1', model: 'gpt-4o-mini', is_active: true, is_default: true },
+  { code: 'anthropic', name: 'Anthropic Claude', base_url: 'https://api.anthropic.com', model: 'claude-3-haiku-20240307', is_active: true, is_default: false, input_price_per_mtok: 3.00, output_price_per_mtok: 15.00 },
+  { code: 'deepseek', name: 'DeepSeek V3', base_url: 'https://api.deepseek.com', model: 'deepseek-chat', is_active: true, is_default: false, input_price_per_mtok: 0.27, output_price_per_mtok: 1.10 },
+  { code: 'xai_grok', name: 'xAI Grok', base_url: 'https://api.x.ai/v1', model: 'grok-4-1-fast-reasoning', is_active: true, is_default: true, input_price_per_mtok: 0.20, output_price_per_mtok: 0.50 },
+  { code: 'openai', name: 'OpenAI', base_url: 'https://api.openai.com/v1', model: 'gpt-4o-mini', is_active: true, is_default: true, input_price_per_mtok: 2.50, output_price_per_mtok: 10.00 },
 ];
 
 async function seed(prisma) {
   for (const item of data) {
     await prisma.llm_providers.upsert({
       where: { code: item.code },
-      update: { name: item.name, base_url: item.base_url, model: item.model, is_active: item.is_active, is_default: item.is_default },
+      update: { name: item.name, base_url: item.base_url, model: item.model, is_active: item.is_active, is_default: item.is_default, input_price_per_mtok: item.input_price_per_mtok, output_price_per_mtok: item.output_price_per_mtok },
       create: item,
     });
   }

--- a/server/scripts/seeds/permissions.js
+++ b/server/scripts/seeds/permissions.js
@@ -33,6 +33,7 @@ const data = [
   { code: 'venues:delete', name: 'Eliminar venues', description: 'Permite eliminar venues' },
   { code: 'venues:edit', name: 'Editar venues', description: 'Permite editar venues' },
   { code: 'venues:view', name: 'Ver venues', description: 'Permite ver venues de organizaciones asignadas' },
+  { code: 'ai-usage:view', name: 'Ver uso de IA', description: 'Permite ver estadísticas y registros de uso de IA' },
 ];
 
 async function seed(prisma) {

--- a/server/scripts/seeds/profiles.js
+++ b/server/scripts/seeds/profiles.js
@@ -20,6 +20,7 @@ const data = [
       'payments:view', 'payments:create', 'payments:edit', 'payments:delete', 'payments:verify',
       'deposits:view', 'deposits:create', 'deposits:edit', 'deposits:delete',
       'contacts:view', 'contacts:create', 'contacts:edit', 'contacts:delete',
+      'ai-usage:view',
     ],
     is_system: true,
   },

--- a/src/_nav.js
+++ b/src/_nav.js
@@ -185,6 +185,12 @@ export default [
   },
   {
     component: 'CNavItem',
+    name: 'Uso de IA',
+    to: '/admin/ai-usage',
+    icon: 'cil-chart',
+  },
+  {
+    component: 'CNavItem',
     name: 'Configuración',
     to: '/settings',
     icon: 'cil-settings',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -554,6 +554,12 @@ const routes = [
         meta: { breadcrumb: 'Análisis Financiero' },
       },
       {
+        path: '/admin/ai-usage',
+        name: 'AIUsage',
+        component: () => import('@/views/analytics/AIUsageView.vue'),
+        meta: { breadcrumb: 'Uso de IA' },
+      },
+      {
         path: '/business/estimates',
         name: 'EstimatesList',
         component: () => import('@/views/estimates/EstimatesListView.vue'),

--- a/src/views/analytics/AIUsageView.vue
+++ b/src/views/analytics/AIUsageView.vue
@@ -1,0 +1,360 @@
+<template>
+  <div>
+    <CCard class="mb-4">
+      <CCardBody>
+        <CRow class="g-3 align-items-end">
+          <CCol :xs="6" :md="3" :lg="2">
+            <label class="form-label">Periodo</label>
+            <CFormSelect v-model="selectedPeriod" @change="loadAllData">
+              <option v-for="opt in periodOptions" :key="opt.value" :value="opt.value">
+                {{ opt.label }}
+              </option>
+            </CFormSelect>
+          </CCol>
+          <CCol :xs="6" :md="3" :lg="2">
+            <label class="form-label">Cabana</label>
+            <CFormSelect v-model="selectedVenueId" @change="loadAllData">
+              <option value="">Todas las cabanas</option>
+              <option v-for="venue in venues" :key="venue.id" :value="venue.id">
+                {{ venue.name }}
+              </option>
+            </CFormSelect>
+          </CCol>
+        </CRow>
+      </CCardBody>
+    </CCard>
+
+    <div v-if="loading" class="text-center py-5">
+      <CSpinner color="primary" />
+      <div class="text-body-secondary mt-2">Cargando datos...</div>
+    </div>
+    <template v-else>
+
+    <CRow class="mb-4 g-3">
+      <CCol :sm="6" :lg="3">
+        <CCard class="cabania-glass-banner cabania-glass-banner--primary h-100">
+          <CCardBody class="pb-3 text-end">
+            <div class="fs-4 fw-semibold">{{ animTotalCalls }}</div>
+            <div class="cabania-glass__label">Total Llamadas</div>
+          </CCardBody>
+        </CCard>
+      </CCol>
+      <CCol :sm="6" :lg="3">
+        <CCard class="cabania-glass-banner cabania-glass-banner--info h-100">
+          <CCardBody class="pb-3 text-end">
+            <div class="fs-4 fw-semibold">{{ animTotalTokens }}</div>
+            <div class="cabania-glass__label">Total Tokens</div>
+          </CCardBody>
+        </CCard>
+      </CCol>
+      <CCol :sm="6" :lg="3">
+        <CCard class="cabania-glass-banner cabania-glass-banner--warning h-100">
+          <CCardBody class="pb-3 text-end">
+            <div class="fs-4 fw-semibold">{{ animTotalCost }}</div>
+            <div class="cabania-glass__label">Costo Estimado</div>
+          </CCardBody>
+        </CCard>
+      </CCol>
+      <CCol :sm="6" :lg="3">
+        <CCard class="cabania-glass-banner cabania-glass-banner--success h-100">
+          <CCardBody class="pb-3 text-end">
+            <div class="fs-4 fw-semibold">{{ animAvgTime }}</div>
+            <div class="cabania-glass__label">Tiempo Promedio</div>
+          </CCardBody>
+        </CCard>
+      </CCol>
+    </CRow>
+
+    <CRow class="mb-4">
+      <CCol :md="6">
+        <CCard class="h-100">
+          <CCardHeader>Costo Mensual por Cabana</CCardHeader>
+          <CCardBody>
+            <div v-if="monthlyByVenue.length > 0" style="height: 300px;">
+              <highcharts :options="costByVenueChartOptions" />
+            </div>
+            <div v-else class="text-center text-body-secondary py-5">
+              No hay datos disponibles
+            </div>
+          </CCardBody>
+        </CCard>
+      </CCol>
+      <CCol :md="6">
+        <CCard class="h-100">
+          <CCardHeader>Uso por Feature</CCardHeader>
+          <CCardBody>
+            <div v-if="summary.byFeature && summary.byFeature.length > 0" style="height: 300px;">
+              <highcharts :options="featurePieChartOptions" />
+            </div>
+            <div v-else class="text-center text-body-secondary py-5">
+              No hay datos de uso por feature
+            </div>
+          </CCardBody>
+        </CCard>
+      </CCol>
+    </CRow>
+
+    <CCard class="mb-4">
+      <CCardHeader>Detalle de Llamadas</CCardHeader>
+      <CCardBody class="p-0">
+        <div class="table-responsive">
+          <table class="table table-hover table-striped mb-0">
+            <thead>
+              <tr>
+                <th>Fecha</th>
+                <th>Feature</th>
+                <th>Cabana</th>
+                <th>Modelo</th>
+                <th class="text-end">Tokens In</th>
+                <th class="text-end">Tokens Out</th>
+                <th class="text-end">Tiempo</th>
+                <th class="text-end">Costo</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in detailData" :key="row.id">
+                <td class="text-nowrap">{{ formatDate(row.created_at) }}</td>
+                <td>
+                  <CBadge :color="featureBadgeColors[row.feature] || 'secondary'" shape="rounded-pill">
+                    {{ featureLabels[row.feature] || row.feature }}
+                  </CBadge>
+                </td>
+                <td>{{ row.venue_name }}</td>
+                <td><small class="text-body-secondary">{{ row.model }}</small></td>
+                <td class="text-end">{{ formatNumber(row.input_tokens) }}</td>
+                <td class="text-end">{{ formatNumber(row.output_tokens) }}</td>
+                <td class="text-end">{{ row.response_time_ms ? row.response_time_ms + ' ms' : '-' }}</td>
+                <td class="text-end">{{ formatCost(row.cost_estimate) }}</td>
+              </tr>
+              <tr v-if="detailData.length === 0">
+                <td colspan="8" class="text-center text-body-secondary py-4">No hay registros</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-if="pagination.totalPages > 1" class="d-flex justify-content-center py-3">
+          <CPagination :pages="pagination.totalPages" :active-page="pagination.page" @update:active-page="goToPage" />
+        </div>
+      </CCardBody>
+    </CCard>
+
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useSettingsStore } from '@/stores/settings'
+import { useAuth } from '@/composables/useAuth'
+import { useAnimatedNumber } from '@/composables/useAnimatedNumber'
+
+const settingsStore = useSettingsStore()
+const { user } = useAuth()
+
+const periodOptions = [
+  { value: 'last_12_months', label: 'Ultimos 12 meses' },
+  { value: 'last_6_months', label: 'Ultimos 6 meses' },
+  { value: 'last_3_months', label: 'Ultimos 3 meses' },
+  { value: 'this_month', label: 'Este mes' },
+  { value: 'this_quarter', label: 'Este trimestre' },
+  { value: 'this_year', label: 'Este ano' }
+]
+
+const featureLabels = {
+  message_generation: 'Mensajes',
+  chat: 'Chat',
+  payment_receipt_extraction: 'Recibo Pago',
+  expense_receipt_analysis: 'Recibo Gasto'
+}
+const featureBadgeColors = {
+  message_generation: 'success',
+  chat: 'info',
+  payment_receipt_extraction: 'warning',
+  expense_receipt_analysis: 'danger'
+}
+
+const selectedPeriod = ref('last_6_months')
+const selectedVenueId = ref('')
+const venues = ref([])
+
+const summary = ref({ totalCalls: 0, totalTokens: 0, totalCost: 0, avgResponseTime: 0, byFeature: [] })
+const monthlyByVenue = ref([])
+const detailData = ref([])
+const pagination = ref({ page: 1, limit: 50, total: 0, totalPages: 0 })
+
+const loading = ref(false)
+
+const animTotalCalls = useAnimatedNumber(computed(() => summary.value.totalCalls), { formatter: formatNumber })
+const animTotalTokens = useAnimatedNumber(computed(() => summary.value.totalTokens), { formatter: formatNumber })
+// Cost uses x10000 scale for animation (useAnimatedNumber rounds to int)
+const animTotalCost = useAnimatedNumber(computed(() => Math.round(summary.value.totalCost * 10000)), { formatter: (n) => '$' + (n / 10000).toFixed(4) })
+const animAvgTime = useAnimatedNumber(computed(() => summary.value.avgResponseTime), { formatter: (n) => n + ' ms' })
+
+const chartColors = [
+  '#10b981', '#0ea5e9', '#6366f1', '#f43f5e', '#f59e0b',
+  '#14b8a6', '#8b5cf6', '#f97316', '#06b6d4', '#ec4899'
+]
+const labelColor = '#94a3b8'
+const gridColor = 'rgba(148, 163, 184, 0.15)'
+
+const costByVenueChartOptions = computed(() => {
+  // Build stacked series: one series per venue
+  const venueSet = new Map()
+  for (const month of monthlyByVenue.value) {
+    for (const v of month.venues) {
+      if (!venueSet.has(v.venue_name)) venueSet.set(v.venue_name, [])
+    }
+  }
+  // Fill data arrays
+  for (const [name] of venueSet) {
+    const data = monthlyByVenue.value.map(month => {
+      const found = month.venues.find(v => v.venue_name === name)
+      return found ? Math.round(found.cost * 10000) / 10000 : 0
+    })
+    venueSet.set(name, data)
+  }
+  const series = []
+  let colorIdx = 0
+  for (const [name, data] of venueSet) {
+    series.push({ name, data, color: chartColors[colorIdx % chartColors.length] })
+    colorIdx++
+  }
+
+  return {
+    chart: {
+      type: 'column',
+      options3d: { enabled: true, alpha: 15, beta: 15, depth: 50 },
+      backgroundColor: 'transparent',
+      height: 300
+    },
+    title: { text: undefined },
+    xAxis: {
+      categories: monthlyByVenue.value.map(m => m.monthName),
+      labels: { style: { color: labelColor } }
+    },
+    yAxis: {
+      title: { text: undefined },
+      min: 0,
+      labels: { style: { color: labelColor }, formatter() { return '$' + this.value } },
+      gridLineColor: gridColor
+    },
+    plotOptions: { column: { stacking: 'normal', depth: 25, borderWidth: 0 } },
+    series,
+    credits: { enabled: false },
+    legend: { enabled: true, itemStyle: { color: labelColor } }
+  }
+})
+
+const featurePieChartOptions = computed(() => ({
+  chart: {
+    type: 'pie',
+    options3d: { enabled: true, alpha: 45, beta: 0 },
+    backgroundColor: 'transparent',
+    height: 300
+  },
+  title: { text: undefined },
+  plotOptions: {
+    pie: {
+      innerSize: '50%',
+      depth: 35,
+      borderWidth: 0,
+      dataLabels: {
+        enabled: true,
+        format: '{point.name}: {point.percentage:.1f}%',
+        style: { color: labelColor, textOutline: 'none' }
+      }
+    }
+  },
+  series: [{
+    data: (summary.value.byFeature || []).map((item, i) => ({
+      name: featureLabels[item.feature] || item.feature,
+      y: item.count,
+      color: chartColors[i % chartColors.length]
+    }))
+  }],
+  credits: { enabled: false }
+}))
+
+function formatNumber(n) {
+  return new Intl.NumberFormat('es-CO').format(n || 0)
+}
+
+function formatCost(amount) {
+  return '$' + (amount || 0).toFixed(4)
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return '-'
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('es-CO', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function getQueryParams() {
+  const viewAll = user.value?.is_super_admin ? settingsStore.godModeViewAll : false
+  const params = new URLSearchParams()
+  params.append('period', selectedPeriod.value)
+  if (selectedVenueId.value) params.append('venue_id', selectedVenueId.value)
+  params.append('viewAll', viewAll.toString())
+  return params.toString()
+}
+
+async function loadVenues() {
+  try {
+    const viewAll = user.value?.is_super_admin ? settingsStore.godModeViewAll : false
+    const response = await fetch(`/api/venues?viewAll=${viewAll}`, { credentials: 'include' })
+    if (response.ok) venues.value = await response.json()
+  } catch (error) {
+    console.error('Error loading venues:', error)
+  }
+}
+
+async function loadSummary() {
+  try {
+    const response = await fetch(`/api/analytics/ai-usage?${getQueryParams()}`, { credentials: 'include' })
+    if (response.ok) summary.value = await response.json()
+  } catch (error) {
+    console.error('Error loading AI usage summary:', error)
+  }
+}
+
+async function loadMonthlyByVenue() {
+  try {
+    const response = await fetch(`/api/analytics/ai-usage-by-venue?${getQueryParams()}`, { credentials: 'include' })
+    if (response.ok) monthlyByVenue.value = await response.json()
+  } catch (error) {
+    console.error('Error loading AI usage by venue:', error)
+  }
+}
+
+async function loadDetail(page = 1) {
+  try {
+    const params = getQueryParams() + `&page=${page}&limit=50`
+    const response = await fetch(`/api/analytics/ai-usage-detail?${params}`, { credentials: 'include' })
+    if (response.ok) {
+      const result = await response.json()
+      detailData.value = result.data
+      pagination.value = result.pagination
+    }
+  } catch (error) {
+    console.error('Error loading AI usage detail:', error)
+  }
+}
+
+function goToPage(page) {
+  loadDetail(page)
+}
+
+async function loadAllData() {
+  loading.value = true
+  try {
+    await Promise.all([loadSummary(), loadMonthlyByVenue(), loadDetail(1)])
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(async () => {
+  await loadVenues()
+  await loadAllData()
+})
+</script>


### PR DESCRIPTION
## Summary
- Nuevo modelo `ai_audit_logs` en Prisma + helper `logAICall()` para auditar todas las llamadas a IA (mensajes, chat, recibos de pago/gasto)
- 3 endpoints de analytics: resumen (`ai-usage`), costo mensual por venue (`ai-usage-by-venue`), detalle paginado (`ai-usage-detail`)
- Nueva vista `AIUsageView.vue` con 4 cards animadas, chart 3D columnas stacked por venue/mes, chart 3D pie por feature, y tabla de detalle con badges de colores y paginación
- Permiso `ai-usage:view` asignado al perfil `organization:admin`
- Migración aplicada a Neon dev y prod

## Test plan
- [ ] Generar un mensaje IA y verificar que se crea registro en `ai_audit_logs`
- [ ] Navegar a `/admin/ai-usage` y verificar cards con datos
- [ ] Verificar chart de columnas por venue/mes y pie por feature
- [ ] Verificar tabla de detalle con paginación y badges
- [ ] Cambiar filtro de período y venue, verificar que datos se actualizan
- [ ] `npm run build` sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)