### PR TITLE
Página pública de venue con booking widget y chat AI

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -386,6 +386,373 @@ async function startServer() {
     }
   });
 
+  // Public venue page endpoint (no auth)
+  app.get('/api/public/venues/:slug', async (req, res) => {
+    try {
+      const venue = await prisma.venues.findUnique({
+        where: { slug: req.params.slug }
+      });
+      if (!venue || !venue.is_public) {
+        return res.status(404).json({ error: 'Venue not found' });
+      }
+
+      // Load images, amenities, and plans in parallel
+      const [images, venueAmenityLinks, plans] = await Promise.all([
+        prisma.venue_images.findMany({
+          where: { venue_id: venue.id },
+          orderBy: { sort_order: 'asc' }
+        }),
+        prisma.venue_amenities.findMany({
+          where: { venue_id: venue.id }
+        }),
+        prisma.venue_plans.findMany({
+          where: { venue_id: venue.id, is_active: true },
+          orderBy: { name: 'asc' }
+        })
+      ]);
+
+      // Resolve amenity details
+      const amenityIds = venueAmenityLinks.map(va => va.amenity_id);
+      const amenities = amenityIds.length > 0
+        ? await prisma.amenities.findMany({ where: { id: { in: amenityIds }, is_active: true } })
+        : [];
+
+      // Load plan amenities
+      const planIds = plans.map(p => p.id);
+      const planAmenityLinks = planIds.length > 0
+        ? await prisma.plan_amenities.findMany({ where: { plan_id: { in: planIds } } })
+        : [];
+      const planAmenityIds = [...new Set(planAmenityLinks.map(pa => pa.amenity_id))];
+      const planAmenities = planAmenityIds.length > 0
+        ? await prisma.amenities.findMany({ where: { id: { in: planAmenityIds } } })
+        : [];
+      const amenityMap = {};
+      for (const a of planAmenities) amenityMap[a.id] = a;
+
+      const plansWithAmenities = plans.map(p => {
+        const pAmenities = planAmenityLinks
+          .filter(pa => pa.plan_id === p.id)
+          .map(pa => ({ ...amenityMap[pa.amenity_id], quantity: pa.quantity, notes: pa.notes }))
+          .filter(Boolean);
+        return { ...p, amenities: pAmenities };
+      });
+
+      // Return only public-safe fields
+      res.json({
+        venue: {
+          id: venue.id, name: venue.name, slug: venue.slug,
+          whatsapp: venue.whatsapp, instagram: venue.instagram,
+          address: venue.address, city: venue.city, department: venue.department,
+          suburb: venue.suburb, country: venue.country, address_reference: venue.address_reference,
+          latitude: venue.latitude, longitude: venue.longitude,
+          waze_link: venue.waze_link, google_maps_link: venue.google_maps_link,
+          venue_info: venue.venue_info, delivery_info: venue.delivery_info,
+          brand_color_primary: venue.brand_color_primary,
+          brand_color_secondary: venue.brand_color_secondary,
+          logo_url: venue.logo_url
+        },
+        images,
+        amenities,
+        plans: plansWithAmenities
+      });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // Public availability check (no auth, no LLM) — used by booking widget
+  const availabilityRateLimit = new Map(); // IP -> { count, resetAt }
+  app.post('/api/public/venues/:id/availability', async (req, res) => {
+    try {
+      // Rate limit: 10 requests per minute per IP
+      const ip = req.ip || req.connection.remoteAddress;
+      const now = Date.now();
+      const rl = availabilityRateLimit.get(ip);
+      if (rl && rl.resetAt > now) {
+        if (rl.count >= 10) {
+          return res.status(429).json({ error: 'Demasiadas consultas. Intenta en un momento.' });
+        }
+        rl.count++;
+      } else {
+        availabilityRateLimit.set(ip, { count: 1, resetAt: now + 60000 });
+      }
+      // Cleanup stale entries every 100 requests
+      if (availabilityRateLimit.size > 500) {
+        for (const [k, v] of availabilityRateLimit) {
+          if (v.resetAt <= now) availabilityRateLimit.delete(k);
+        }
+      }
+
+      const venueId = req.params.id;
+      const { check_in, check_out, adults, children, plan_id } = req.body;
+
+      if (!check_in) {
+        return res.status(400).json({ error: 'check_in es requerido' });
+      }
+
+      const venue = await prisma.venues.findUnique({ where: { id: venueId } });
+      if (!venue || !venue.is_public) {
+        return res.status(404).json({ error: 'Venue not found' });
+      }
+
+      // Parse and validate dates
+      const checkInDate = new Date(check_in);
+      const checkOutDate = check_out ? new Date(check_out) : checkInDate;
+      const today = new Date();
+      today.setUTCHours(0, 0, 0, 0);
+      const checkInDay = new Date(checkInDate.getUTCFullYear(), checkInDate.getUTCMonth(), checkInDate.getUTCDate());
+      const checkOutDay = new Date(checkOutDate.getUTCFullYear(), checkOutDate.getUTCMonth(), checkOutDate.getUTCDate());
+
+      if (checkInDay < today) {
+        return res.status(400).json({ error: 'La fecha de llegada está en el pasado.' });
+      }
+      if (checkOutDay < checkInDay) {
+        return res.status(400).json({ error: 'La fecha de salida debe ser igual o posterior a la de llegada.' });
+      }
+
+      const numAdults = parseInt(adults) || 1;
+      const numChildren = parseInt(children) || 0;
+      const totalGuests = numAdults + numChildren;
+
+      // Check overlapping accommodations
+      const existingAccommodations = await prisma.accommodations.findMany({
+        where: { venue: venueId }
+      });
+
+      let isAvailable = true;
+      for (const acc of existingAccommodations) {
+        const accDate = new Date(acc.date);
+        const durationSeconds = parseInt(acc.duration) || 43200;
+        const accEndDate = new Date(accDate.getTime() + durationSeconds * 1000);
+        const accStartDay = new Date(accDate.getUTCFullYear(), accDate.getUTCMonth(), accDate.getUTCDate());
+        const accEndDay = new Date(accEndDate.getUTCFullYear(), accEndDate.getUTCMonth(), accEndDate.getUTCDate());
+
+        if (accStartDay <= checkOutDay && accEndDay >= checkInDay) {
+          isAvailable = false;
+          break;
+        }
+      }
+
+      // Load active plans for this venue
+      const plans = await prisma.venue_plans.findMany({
+        where: { venue_id: venueId, is_active: true },
+        orderBy: { name: 'asc' }
+      });
+
+      // Filter suitable plans by guest count (and optionally by plan_id)
+      const suitablePlans = plans.filter(p => {
+        const planMin = p.min_guests || 1;
+        const planMax = p.max_capacity || 999;
+        const fits = totalGuests >= planMin && totalGuests <= planMax;
+        return plan_id ? (fits && p.id === plan_id) : fits;
+      }).map(p => {
+        const adultTotal = numAdults * parseFloat(p.adult_price);
+        const childTotal = numChildren * parseFloat(p.child_price);
+        return {
+          id: p.id,
+          name: p.name,
+          plan_type: p.plan_type,
+          adult_price: parseFloat(p.adult_price),
+          child_price: parseFloat(p.child_price),
+          estimated_total: adultTotal + childTotal,
+          check_in_time: p.check_in_time,
+          check_out_time: p.check_out_time,
+          includes_overnight: p.includes_overnight
+        };
+      });
+
+      // Get next available dates if not available
+      let nextAvailableDates = [];
+      if (!isAvailable) {
+        const checkInDayOfWeek = checkInDate.getDay();
+        const preferWeekends = checkInDayOfWeek === 0 || checkInDayOfWeek === 6;
+        const stayLength = Math.max(1, Math.ceil((checkOutDay - checkInDay) / (1000 * 60 * 60 * 24)) + 1);
+        nextAvailableDates = llmService.getNextAvailableDates(existingAccommodations, checkInDate, {
+          preferWeekends,
+          stayLength,
+          numDays: 30
+        });
+      }
+
+      res.json({
+        is_available: isAvailable,
+        check_in: check_in,
+        check_out: check_out || check_in,
+        adults: numAdults,
+        children: numChildren,
+        total_guests: totalGuests,
+        suitable_plans: suitablePlans,
+        next_available_dates: nextAvailableDates
+      });
+    } catch (error) {
+      console.error('Availability check error:', error);
+      res.status(500).json({ error: 'Error checking availability' });
+    }
+  });
+
+  // Public conversation loader (no auth) — restores chat for returning visitors
+  app.get('/api/public/chat/conversation/:id', async (req, res) => {
+    try {
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!uuidRegex.test(req.params.id)) {
+        return res.status(400).json({ error: 'Invalid conversation ID' });
+      }
+
+      const conversation = await prisma.chat_conversations.findUnique({
+        where: { id: req.params.id },
+        include: {
+          messages: {
+            orderBy: { created_at: 'asc' },
+            select: { role: true, content: true, created_at: true }
+          }
+        }
+      });
+
+      if (!conversation) {
+        return res.status(404).json({ error: 'Conversation not found' });
+      }
+
+      const messages = conversation.messages.map(m => ({
+        role: m.role,
+        content: m.content.replace(/\n<!-- \{.*?\} -->/g, ''),
+        created_at: m.created_at
+      }));
+
+      const messageCount = messages.filter(m => m.role === 'user').length;
+      const limitSetting = await prisma.app_settings.findUnique({
+        where: { setting_key: 'public_chat_free_limit' }
+      });
+      const freeLimit = parseInt(limitSetting?.setting_value) || 20;
+      const isVerified = conversation.metadata?.verified === true;
+
+      res.json({
+        id: conversation.id,
+        venue_id: conversation.venue_id,
+        name: conversation.name,
+        phone: conversation.phone,
+        messages,
+        message_count: messageCount,
+        free_limit: freeLimit,
+        is_verified: isVerified
+      });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // Request verification code for public chat
+  app.post('/api/public/chat/verify/request', async (req, res) => {
+    try {
+      const { conversation_id, phone } = req.body;
+      if (!conversation_id || !phone) {
+        return res.status(400).json({ error: 'conversation_id and phone are required' });
+      }
+
+      const conversation = await prisma.chat_conversations.findUnique({
+        where: { id: conversation_id }
+      });
+      if (!conversation) {
+        return res.status(404).json({ error: 'Conversation not found' });
+      }
+
+      // Rate limit: max 3 requests per hour
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      const recentRequests = await prisma.public_chat_verifications.count({
+        where: { conversation_id, created_at: { gte: oneHourAgo } }
+      });
+      if (recentRequests >= 3) {
+        return res.status(429).json({ error: 'Demasiadas solicitudes. Intenta de nuevo en una hora.' });
+      }
+
+      const code = String(Math.floor(100000 + Math.random() * 900000));
+
+      await prisma.public_chat_verifications.create({
+        data: {
+          conversation_id,
+          phone,
+          code,
+          expires_at: new Date(Date.now() + 10 * 60 * 1000)
+        }
+      });
+
+      // TODO: Send code via WhatsApp (future integration)
+      const response = { success: true, message: 'Código de verificación generado' };
+      if (process.env.NODE_ENV !== 'production') {
+        response.code = code; // Dev only
+      }
+      res.json(response);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // Confirm verification code for public chat
+  app.post('/api/public/chat/verify/confirm', async (req, res) => {
+    try {
+      const { conversation_id, code } = req.body;
+      if (!conversation_id || !code) {
+        return res.status(400).json({ error: 'conversation_id and code are required' });
+      }
+
+      const verification = await prisma.public_chat_verifications.findFirst({
+        where: {
+          conversation_id,
+          status: 'pending',
+          expires_at: { gte: new Date() }
+        },
+        orderBy: { created_at: 'desc' }
+      });
+
+      if (!verification) {
+        return res.status(404).json({ error: 'No hay código pendiente o ya expiró' });
+      }
+
+      if (verification.attempts >= 5) {
+        await prisma.public_chat_verifications.update({
+          where: { id: verification.id },
+          data: { status: 'expired' }
+        });
+        return res.status(429).json({ error: 'Demasiados intentos. Solicita un nuevo código.' });
+      }
+
+      await prisma.public_chat_verifications.update({
+        where: { id: verification.id },
+        data: { attempts: verification.attempts + 1 }
+      });
+
+      if (verification.code !== code.trim()) {
+        return res.status(400).json({
+          error: 'Código incorrecto',
+          attempts_remaining: 5 - (verification.attempts + 1)
+        });
+      }
+
+      // Mark verified
+      await prisma.public_chat_verifications.update({
+        where: { id: verification.id },
+        data: { status: 'verified', verified_at: new Date() }
+      });
+
+      // Update conversation metadata
+      const conversation = await prisma.chat_conversations.findUnique({
+        where: { id: conversation_id }
+      });
+      const metadata = conversation.metadata || {};
+      metadata.verified = true;
+      metadata.verified_at = new Date().toISOString();
+      metadata.verified_phone = verification.phone;
+
+      await prisma.chat_conversations.update({
+        where: { id: conversation_id },
+        data: { metadata, phone: verification.phone, updated_at: new Date() }
+      });
+
+      res.json({ success: true, verified: true });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
   app.get('/api/venues/:id', async (req, res) => {
     try {
       const venue = await prisma.venues.findUnique({
@@ -417,6 +784,26 @@ async function startServer() {
       if (data.deposit_refund_hours !== undefined) {
         data.deposit_refund_hours = data.deposit_refund_hours ? parseInt(data.deposit_refund_hours, 10) : null;
       }
+
+      // Auto-generate slug when is_public=true and slug is empty
+      if (data.is_public && !data.slug && data.name) {
+        let baseSlug = data.name
+          .toLowerCase()
+          .normalize('NFD').replace(/[\u0300-\u036f]/g, '') // remove accents
+          .replace(/[^a-z0-9\s-]/g, '')
+          .replace(/\s+/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-|-$/g, '');
+        let slug = baseSlug;
+        let suffix = 1;
+        while (true) {
+          const existing = await prisma.venues.findUnique({ where: { slug } });
+          if (!existing || existing.id === req.params.id) break;
+          slug = `${baseSlug}-${suffix++}`;
+        }
+        data.slug = slug;
+      }
+
       const venue = await prisma.venues.update({
         where: { id: req.params.id },
         data
@@ -5200,13 +5587,47 @@ REGLAS:
             venue_id,
             source,
             external_id: externalId,
-            phone,
-            name: userName
+            phone: phone || req.body.visitor_phone || null,
+            name: userName || req.body.visitor_name || null
           }
         });
         conversation.messages = [];
       }
-      
+
+      // Update visitor info if provided
+      if (req.body.visitor_name || req.body.visitor_phone) {
+        const updateData = { updated_at: new Date() };
+        if (req.body.visitor_name && !conversation.name) updateData.name = req.body.visitor_name;
+        if (req.body.visitor_phone && !conversation.phone) updateData.phone = req.body.visitor_phone;
+        if (Object.keys(updateData).length > 1) {
+          await prisma.chat_conversations.update({
+            where: { id: conversation.id },
+            data: updateData
+          });
+        }
+      }
+
+      // Check free tier limit for public (non-authenticated) requests
+      if (!req.user) {
+        const limitSetting = await prisma.app_settings.findUnique({
+          where: { setting_key: 'public_chat_free_limit' }
+        });
+        const freeLimit = parseInt(limitSetting?.setting_value) || 20;
+        const isVerified = conversation.metadata?.verified === true;
+        const userMsgCount = conversation.messages
+          ? conversation.messages.filter(m => m.role === 'user').length
+          : 0;
+
+        if (!isVerified && userMsgCount >= freeLimit) {
+          return res.status(403).json({
+            error: 'free_limit_reached',
+            message_count: userMsgCount,
+            free_limit: freeLimit,
+            requires_verification: true
+          });
+        }
+      }
+
       // Save user message
       await prisma.chat_messages.create({
         data: {
@@ -5669,12 +6090,23 @@ REGLAS:
         data: { updated_at: new Date() }
       });
       
+      // Count user messages for limit tracking
+      const updatedMsgCount = await prisma.chat_messages.count({
+        where: { conversation_id: conversation.id, role: 'user' }
+      });
+      const limitSetting2 = await prisma.app_settings.findUnique({
+        where: { setting_key: 'public_chat_free_limit' }
+      });
+
       res.json({
         conversation_id: conversation.id,
         message: llmResponse.content,
         provider: chatProviderCode,
         model: llmResponse.model,
-        tokens_used: llmResponse.usage?.total_tokens
+        tokens_used: llmResponse.usage?.total_tokens,
+        message_count: updatedMsgCount,
+        free_limit: parseInt(limitSetting2?.setting_value) || 20,
+        is_verified: conversation.metadata?.verified === true
       });
     } catch (error) {
       console.error('Chat error:', error);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -225,6 +225,7 @@ model venues {
   instagram            String?       @db.VarChar
   organization         String?       @db.Uuid
   is_public            Boolean       @default(false)
+  slug                 String?       @unique @db.VarChar(100)
   waze_link            String?
   google_maps_link     String?
   default_llm_provider String?       @db.Uuid
@@ -237,6 +238,9 @@ model venues {
   deposit_per_extra_person      Decimal?  @db.Decimal
   deposit_refund_hours          Int?
   deposit_policy                String?
+  brand_color_primary   String?   @db.VarChar(7)
+  brand_color_secondary String?   @db.VarChar(7)
+  logo_url              String?
   venue_plans          venue_plans[]
 }
 
@@ -762,4 +766,25 @@ model commission_payments {
   updated_at        DateTime?         @db.Timestamptz(6)
   updated_by        String?           @db.VarChar(255)
   agent             commission_agents @relation(fields: [agent_id], references: [id])
+}
+
+model app_settings {
+  id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  setting_key   String    @unique @db.VarChar(100)
+  setting_value String    @db.VarChar(500)
+  description   String?
+  created_at    DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at    DateTime? @db.Timestamptz(6)
+}
+
+model public_chat_verifications {
+  id              String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  conversation_id String    @db.Uuid
+  phone           String    @db.VarChar(50)
+  code            String    @db.VarChar(6)
+  status          String    @default("pending") @db.VarChar(20)
+  attempts        Int       @default(0)
+  expires_at      DateTime  @db.Timestamptz(6)
+  verified_at     DateTime? @db.Timestamptz(6)
+  created_at      DateTime  @default(now()) @db.Timestamptz(6)
 }

--- a/server/scripts/seed-all.js
+++ b/server/scripts/seed-all.js
@@ -11,6 +11,7 @@ const seeds = [
   { name: 'amenities', fn: require('./seeds/amenities') },
   { name: 'countries', fn: require('./seeds/countries') },
   { name: 'states', fn: require('./seeds/states') },
+  { name: 'app_settings', fn: require('./seeds/app-settings') },
 ];
 
 async function seedAll() {

--- a/src/components/public/BookingPanelWidget.vue
+++ b/src/components/public/BookingPanelWidget.vue
@@ -1,0 +1,372 @@
+<template>
+  <!-- Overlay backdrop (mobile) -->
+  <Transition name="fade">
+    <div v-if="isOpen" class="booking-backdrop" @click="close"></div>
+  </Transition>
+
+  <!-- Panel -->
+  <Transition name="booking-panel">
+    <div v-if="isOpen" class="booking-panel">
+      <!-- Header -->
+      <div class="booking-panel-header">
+        <button class="header-back" v-if="step > 0 && step < 4" @click="goBack">
+          <svg viewBox="0 0 24 24" fill="none" width="18" height="18"><path d="M15 18l-6-6 6-6" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <span class="header-title">{{ stepTitle }}</span>
+        <button class="header-close" @click="close">
+          <svg viewBox="0 0 24 24" fill="none" width="16" height="16"><path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
+        </button>
+      </div>
+
+      <!-- Step dots -->
+      <div class="step-dots">
+        <span v-for="i in 4" :key="i" :class="['step-dot', { active: step >= i - 1, current: step === i - 1 }]"></span>
+      </div>
+
+      <!-- Step content -->
+      <div class="booking-panel-body">
+        <BookingStepPlan
+          v-if="step === 0"
+          :plans="plans"
+          :selected="selectedPlan"
+          @select="onPlanSelect"
+        />
+        <BookingStepDate
+          v-if="step === 1"
+          :plan="selectedPlan"
+          :initial-data="dateData"
+          @update="onDateUpdate"
+          @check="onCheckAvailability"
+        />
+        <BookingStepResult
+          v-if="step === 2"
+          :loading="checking"
+          :result="availResult"
+          :error-msg="availError"
+          @continue="step = 3"
+          @back="step = 1"
+          @pick-alt-date="onPickAltDate"
+        />
+        <BookingStepContact
+          v-if="step === 3"
+          :summary="bookingSummary"
+          :initial-contact="contactData"
+          @submit="onContactSubmit"
+        />
+      </div>
+
+      <!-- Footer -->
+      <div class="booking-panel-footer">
+        <span class="footer-text">Powered by</span>
+        <img src="/logo-inverted.svg" alt="CabanIA" class="footer-logo-icon" />
+        <img src="/logo-wordmark.svg" alt="CabanIA" class="footer-logo-wordmark" />
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import BookingStepPlan from './BookingStepPlan.vue'
+import BookingStepDate from './BookingStepDate.vue'
+import BookingStepResult from './BookingStepResult.vue'
+import BookingStepContact from './BookingStepContact.vue'
+
+const props = defineProps({
+  venueId: { type: String, required: true },
+  plans: { type: Array, required: true }
+})
+
+const emit = defineEmits(['chat-handoff'])
+
+const isOpen = ref(false)
+const step = ref(0)
+
+const selectedPlan = ref(null)
+const dateData = ref(null)
+const availResult = ref(null)
+const availError = ref('')
+const checking = ref(false)
+const contactData = ref(null)
+
+const stepTitle = computed(() => {
+  const titles = ['Elige un plan', 'Fecha y personas', 'Disponibilidad', 'Tus datos']
+  return titles[step.value] || ''
+})
+
+const bookingSummary = computed(() => {
+  const plan = selectedPlan.value
+  const dates = dateData.value || {}
+  const match = availResult.value?.suitable_plans?.find(sp => sp.id === plan?.id)
+  return {
+    planName: plan?.name || '',
+    checkIn: dates.checkIn || '',
+    checkOut: dates.checkOut || dates.checkIn || '',
+    adults: dates.adults || 1,
+    children: dates.children || 0,
+    estimatedTotal: match?.estimated_total || null
+  }
+})
+
+const open = (plan) => {
+  isOpen.value = true
+  if (plan) {
+    selectedPlan.value = plan
+    step.value = 1
+  } else {
+    step.value = 0
+  }
+}
+
+const close = () => {
+  isOpen.value = false
+}
+
+const goBack = () => {
+  if (step.value > 0) step.value--
+}
+
+const onPlanSelect = (plan) => {
+  selectedPlan.value = plan
+  step.value = 1
+}
+
+const onDateUpdate = (data) => {
+  dateData.value = data
+}
+
+const onCheckAvailability = async () => {
+  if (!dateData.value?.checkIn) return
+  checking.value = true
+  availResult.value = null
+  availError.value = ''
+  step.value = 2
+
+  try {
+    const body = {
+      check_in: dateData.value.checkIn,
+      check_out: dateData.value.checkOut || dateData.value.checkIn,
+      adults: dateData.value.adults,
+      children: dateData.value.children,
+      plan_id: selectedPlan.value?.id
+    }
+    const res = await fetch(`/api/public/venues/${props.venueId}/availability`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      availError.value = err.error || 'Error al consultar disponibilidad'
+      return
+    }
+    availResult.value = await res.json()
+  } catch {
+    availError.value = 'Error de conexión. Intenta de nuevo.'
+  } finally {
+    checking.value = false
+  }
+}
+
+const onPickAltDate = (dateStr) => {
+  dateData.value = { ...dateData.value, checkIn: dateStr, checkOut: dateStr }
+  step.value = 1
+}
+
+const onContactSubmit = (contact) => {
+  contactData.value = contact
+  const summary = bookingSummary.value
+  emit('chat-handoff', {
+    name: contact.name,
+    contactType: contact.contactType,
+    contactValue: contact.contactValue,
+    plan: selectedPlan.value,
+    checkIn: summary.checkIn,
+    checkOut: summary.checkOut,
+    adults: summary.adults,
+    children: summary.children,
+    estimatedTotal: summary.estimatedTotal
+  })
+  close()
+}
+
+defineExpose({ open, close })
+</script>
+
+<style scoped>
+.booking-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  z-index: 10001;
+}
+
+.booking-panel {
+  position: fixed;
+  bottom: 5.5rem;
+  right: 1.5rem;
+  width: 380px;
+  max-width: calc(100vw - 2rem);
+  max-height: 75vh;
+  background: var(--cabania-surface-bg, rgba(255, 255, 255, 0.92));
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--cabania-border, rgba(0, 0, 0, 0.08));
+  border-radius: 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(255,255,255,0.1) inset;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 10002;
+}
+
+/* Header */
+.booking-panel-header {
+  padding: 0.6rem 0.75rem;
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.65));
+  border-bottom: 1px solid var(--cabania-border-subtle, rgba(0, 0, 0, 0.05));
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.header-back {
+  background: none;
+  border: none;
+  padding: 0.2rem;
+  cursor: pointer;
+  color: var(--cabania-text-muted, #64748b);
+  display: flex;
+  align-items: center;
+  border-radius: 50%;
+  transition: background 0.2s;
+}
+
+.header-back:hover {
+  background: var(--cabania-hover-bg, rgba(0, 0, 0, 0.04));
+}
+
+.header-title {
+  flex: 1;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--cabania-text, #0f172a);
+}
+
+.header-close {
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+  color: var(--cabania-text-muted, #64748b);
+  display: flex;
+  align-items: center;
+  border-radius: 50%;
+  transition: background 0.2s;
+}
+
+.header-close:hover {
+  background: var(--cabania-hover-bg, rgba(0, 0, 0, 0.04));
+}
+
+/* Step dots */
+.step-dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0 0.25rem;
+  flex-shrink: 0;
+}
+
+.step-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--cabania-border, rgba(0, 0, 0, 0.12));
+  transition: all 0.3s;
+}
+
+.step-dot.active {
+  background: rgba(16, 185, 129, 0.4);
+}
+
+.step-dot.current {
+  background: #10b981;
+  transform: scale(1.3);
+}
+
+/* Body */
+.booking-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+/* Footer */
+.booking-panel-footer {
+  padding: 0.4rem 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border-top: 1px solid var(--cabania-border-subtle, rgba(0, 0, 0, 0.05));
+  flex-shrink: 0;
+}
+
+.footer-text {
+  font-size: 0.7rem;
+  color: var(--cabania-text-muted, #94a3b8);
+}
+
+.footer-logo-icon {
+  height: 14px;
+  width: 14px;
+  border-radius: 0.2rem;
+  object-fit: contain;
+  opacity: 0.6;
+}
+
+.footer-logo-wordmark {
+  height: 12px;
+  width: auto;
+  opacity: 0.5;
+}
+
+/* Transitions */
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.25s;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+
+.booking-panel-enter-active {
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.booking-panel-leave-active {
+  transition: all 0.2s ease-in;
+}
+.booking-panel-enter-from {
+  opacity: 0;
+  transform: translateY(1rem) scale(0.95);
+}
+.booking-panel-leave-to {
+  opacity: 0;
+  transform: translateY(0.5rem) scale(0.98);
+}
+
+/* Mobile */
+@media (max-width: 640px) {
+  .booking-panel {
+    bottom: 0;
+    right: 0;
+    left: 0;
+    width: auto;
+    max-height: 85vh;
+    border-radius: 1.25rem 1.25rem 0 0;
+  }
+}
+</style>

--- a/src/components/public/BookingStepContact.vue
+++ b/src/components/public/BookingStepContact.vue
@@ -1,0 +1,261 @@
+<template>
+  <div class="step-contact">
+    <!-- Booking Summary -->
+    <div class="booking-summary">
+      <div class="summary-row">
+        <span class="summary-label">Plan</span>
+        <span class="summary-value">{{ summary.planName }}</span>
+      </div>
+      <div class="summary-row">
+        <span class="summary-label">Fecha</span>
+        <span class="summary-value">{{ formatDate(summary.checkIn) }}
+          <template v-if="summary.checkOut !== summary.checkIn"> &rarr; {{ formatDate(summary.checkOut) }}</template>
+        </span>
+      </div>
+      <div class="summary-row">
+        <span class="summary-label">Personas</span>
+        <span class="summary-value">{{ summary.adults }} adulto(s){{ summary.children ? `, ${summary.children} niño(s)` : '' }}</span>
+      </div>
+      <div v-if="summary.estimatedTotal" class="summary-row total">
+        <span class="summary-label">Estimado</span>
+        <span class="summary-value">{{ formatCurrency(summary.estimatedTotal) }}</span>
+      </div>
+    </div>
+
+    <!-- Contact Form -->
+    <div class="contact-form">
+      <div class="field-group">
+        <label class="field-label">Tu nombre</label>
+        <input
+          type="text"
+          class="field-input"
+          v-model="name"
+          placeholder="Nombre completo"
+          @input="validate"
+        />
+      </div>
+
+      <div class="contact-type-toggle">
+        <button
+          :class="['toggle-btn', { active: contactType === 'whatsapp' }]"
+          @click="contactType = 'whatsapp'"
+        >
+          WhatsApp
+        </button>
+        <button
+          :class="['toggle-btn', { active: contactType === 'instagram' }]"
+          @click="contactType = 'instagram'"
+        >
+          Instagram
+        </button>
+      </div>
+
+      <div class="field-group">
+        <label class="field-label">{{ contactType === 'whatsapp' ? 'Número WhatsApp' : 'Usuario Instagram' }}</label>
+        <input
+          type="text"
+          class="field-input"
+          v-model="contactValue"
+          :placeholder="contactType === 'whatsapp' ? '+57 300 123 4567' : '@usuario'"
+          @input="validate"
+        />
+      </div>
+    </div>
+
+    <p class="contact-hint">Podrás hacer preguntas antes de confirmar tu reserva.</p>
+
+    <button
+      class="submit-btn"
+      :disabled="!isValid"
+      @click="onSubmit"
+    >
+      Enviar solicitud de reserva
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  summary: { type: Object, required: true },
+  initialContact: { type: Object, default: null }
+})
+
+const emit = defineEmits(['submit'])
+
+const name = ref(props.initialContact?.name || '')
+const contactType = ref(props.initialContact?.contactType || 'whatsapp')
+const contactValue = ref(props.initialContact?.contactValue || '')
+const isValid = ref(false)
+
+const validate = () => {
+  isValid.value = name.value.trim().length >= 2 && contactValue.value.trim().length >= 3
+}
+
+// Validate on mount if initial data
+if (props.initialContact) validate()
+
+const onSubmit = () => {
+  if (!isValid.value) return
+  emit('submit', {
+    name: name.value.trim(),
+    contactType: contactType.value,
+    contactValue: contactValue.value.trim()
+  })
+}
+
+const formatCurrency = (value) => {
+  return new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value)
+}
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return ''
+  const d = new Date(dateStr + 'T12:00:00')
+  return d.toLocaleDateString('es-CO', { weekday: 'short', day: 'numeric', month: 'short' })
+}
+</script>
+
+<style scoped>
+.step-contact {
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.booking-summary {
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.5));
+  border: 1px solid var(--cabania-border, rgba(0, 0, 0, 0.06));
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+}
+
+.summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.2rem 0;
+}
+
+.summary-row.total {
+  border-top: 1px solid var(--cabania-border, rgba(0, 0, 0, 0.06));
+  margin-top: 0.25rem;
+  padding-top: 0.4rem;
+}
+
+.summary-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--cabania-text-muted, #94a3b8);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.summary-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--cabania-text, #0f172a);
+}
+
+.summary-row.total .summary-value {
+  font-weight: 800;
+  color: #10b981;
+  font-size: 0.95rem;
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.field-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--cabania-text-muted, #64748b);
+  margin-bottom: 0.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.field-input {
+  width: 100%;
+  padding: 0.55rem 0.65rem;
+  border: 1.5px solid var(--cabania-border, rgba(0, 0, 0, 0.12));
+  border-radius: 10px;
+  font-size: 0.9rem;
+  color: var(--cabania-text, #0f172a);
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.65));
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.field-input:focus {
+  outline: none;
+  border-color: #10b981;
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.1);
+}
+
+.contact-type-toggle {
+  display: flex;
+  gap: 0.35rem;
+  background: var(--cabania-card-bg, rgba(0, 0, 0, 0.03));
+  border-radius: 10px;
+  padding: 0.2rem;
+}
+
+.toggle-btn {
+  flex: 1;
+  padding: 0.4rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: transparent;
+  color: var(--cabania-text-muted, #64748b);
+  transition: all 0.2s;
+}
+
+.toggle-btn.active {
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.9));
+  color: #10b981;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.contact-hint {
+  font-size: 0.8rem;
+  color: var(--cabania-text-muted, #94a3b8);
+  text-align: center;
+  margin: 0;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 0.7rem;
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.15s;
+  box-shadow: 0 4px 16px rgba(16, 185, 129, 0.25);
+}
+
+.submit-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.submit-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/public/BookingStepDate.vue
+++ b/src/components/public/BookingStepDate.vue
@@ -1,0 +1,221 @@
+<template>
+  <div class="step-date">
+    <div class="date-fields">
+      <div class="field-group">
+        <label class="field-label">Fecha de llegada</label>
+        <input
+          type="date"
+          class="field-input"
+          :min="minDate"
+          v-model="checkIn"
+          @change="emitUpdate"
+        />
+      </div>
+      <div v-if="showCheckOut" class="field-group">
+        <label class="field-label">Fecha de salida</label>
+        <input
+          type="date"
+          class="field-input"
+          :min="checkIn || minDate"
+          v-model="checkOut"
+          @change="emitUpdate"
+        />
+      </div>
+    </div>
+
+    <div class="guest-fields">
+      <div class="guest-group">
+        <label class="field-label">Adultos</label>
+        <div class="stepper">
+          <button class="stepper-btn" @click="changeAdults(-1)" :disabled="adults <= 1">-</button>
+          <span class="stepper-value">{{ adults }}</span>
+          <button class="stepper-btn" @click="changeAdults(1)" :disabled="adults >= 50">+</button>
+        </div>
+      </div>
+      <div class="guest-group">
+        <label class="field-label">Niños</label>
+        <div class="stepper">
+          <button class="stepper-btn" @click="changeChildren(-1)" :disabled="children <= 0">-</button>
+          <span class="stepper-value">{{ children }}</span>
+          <button class="stepper-btn" @click="changeChildren(1)" :disabled="children >= 50">+</button>
+        </div>
+      </div>
+    </div>
+
+    <button
+      class="check-btn"
+      :disabled="!isValid"
+      @click="$emit('check')"
+    >
+      Consultar disponibilidad
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  plan: { type: Object, default: null },
+  initialData: { type: Object, default: null }
+})
+
+const emit = defineEmits(['update', 'check'])
+
+const today = new Date()
+const minDate = today.toISOString().split('T')[0]
+
+const checkIn = ref(props.initialData?.checkIn || '')
+const checkOut = ref(props.initialData?.checkOut || '')
+const adults = ref(props.initialData?.adults || 2)
+const children = ref(props.initialData?.children || 0)
+
+const showCheckOut = computed(() => props.plan?.includes_overnight)
+
+const isValid = computed(() => {
+  if (!checkIn.value) return false
+  if (showCheckOut.value && !checkOut.value) return false
+  return true
+})
+
+const changeAdults = (delta) => {
+  adults.value = Math.max(1, Math.min(50, adults.value + delta))
+  emitUpdate()
+}
+
+const changeChildren = (delta) => {
+  children.value = Math.max(0, Math.min(50, children.value + delta))
+  emitUpdate()
+}
+
+const emitUpdate = () => {
+  emit('update', {
+    checkIn: checkIn.value,
+    checkOut: showCheckOut.value ? checkOut.value : checkIn.value,
+    adults: adults.value,
+    children: children.value
+  })
+}
+</script>
+
+<style scoped>
+.step-date {
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.date-fields {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.field-group {
+  flex: 1;
+}
+
+.field-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--cabania-text-muted, #64748b);
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.field-input {
+  width: 100%;
+  padding: 0.55rem 0.65rem;
+  border: 1.5px solid var(--cabania-border, rgba(0, 0, 0, 0.12));
+  border-radius: 10px;
+  font-size: 0.9rem;
+  color: var(--cabania-text, #0f172a);
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.65));
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.field-input:focus {
+  outline: none;
+  border-color: #10b981;
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.1);
+}
+
+.guest-fields {
+  display: flex;
+  gap: 1rem;
+}
+
+.guest-group {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.stepper-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1.5px solid var(--cabania-border, rgba(0, 0, 0, 0.12));
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.65));
+  color: var(--cabania-text, #0f172a);
+  font-size: 1.1rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.stepper-btn:hover:not(:disabled) {
+  border-color: #10b981;
+  background: rgba(16, 185, 129, 0.08);
+}
+
+.stepper-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.stepper-value {
+  min-width: 2rem;
+  text-align: center;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--cabania-text, #0f172a);
+}
+
+.check-btn {
+  width: 100%;
+  padding: 0.7rem;
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.15s;
+  box-shadow: 0 4px 16px rgba(16, 185, 129, 0.25);
+}
+
+.check-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(16, 185, 129, 0.35);
+}
+
+.check-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/public/BookingStepPlan.vue
+++ b/src/components/public/BookingStepPlan.vue
@@ -1,0 +1,148 @@
+<template>
+  <div class="step-plan">
+    <p class="step-hint">Selecciona un plan para continuar</p>
+    <div class="plan-list">
+      <button
+        v-for="plan in plans"
+        :key="plan.id"
+        :class="['plan-option', { selected: selected?.id === plan.id }]"
+        @click="$emit('select', plan)"
+      >
+        <div class="plan-option-header">
+          <span class="plan-option-name">{{ plan.name }}</span>
+          <span class="plan-option-badge">{{ planTypeLabel(plan.plan_type) }}</span>
+        </div>
+        <div class="plan-option-prices">
+          <span v-if="plan.adult_price" class="plan-option-price">
+            {{ formatCurrency(plan.adult_price) }} <small>/adulto</small>
+          </span>
+          <span v-if="plan.child_price" class="plan-option-price child">
+            {{ formatCurrency(plan.child_price) }} <small>/niño</small>
+          </span>
+        </div>
+        <div v-if="plan.check_in_time || plan.check_out_time" class="plan-option-schedule">
+          <span v-if="plan.check_in_time">Entrada {{ plan.check_in_time }}</span>
+          <span v-if="plan.check_in_time && plan.check_out_time"> · </span>
+          <span v-if="plan.check_out_time">Salida {{ plan.check_out_time }}</span>
+        </div>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  plans: { type: Array, required: true },
+  selected: { type: Object, default: null }
+})
+
+defineEmits(['select'])
+
+const planTypeLabel = (type) => {
+  const labels = { day: 'Pasadía', pasadia: 'Pasadía', overnight: 'Hospedaje', hospedaje: 'Hospedaje', event: 'Evento', evento: 'Evento', camping: 'Camping' }
+  return labels[type] || type
+}
+
+const formatCurrency = (value) => {
+  return new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value)
+}
+</script>
+
+<style scoped>
+.step-plan {
+  padding: 0.75rem;
+}
+
+.step-hint {
+  font-size: 0.85rem;
+  color: var(--cabania-text-muted, #64748b);
+  margin: 0 0 0.75rem;
+  text-align: center;
+}
+
+.plan-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.plan-option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.75rem;
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.65));
+  border: 2px solid var(--cabania-border, rgba(0, 0, 0, 0.08));
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
+}
+
+.plan-option:hover {
+  border-color: rgba(16, 185, 129, 0.3);
+  transform: translateY(-1px);
+}
+
+.plan-option.selected {
+  border-color: #10b981;
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
+}
+
+.plan-option-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.plan-option-name {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--cabania-text, #0f172a);
+}
+
+.plan-option-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  background: rgba(14, 165, 233, 0.1);
+  border: 1px solid rgba(14, 165, 233, 0.15);
+  color: #0369a1;
+  white-space: nowrap;
+}
+
+.plan-option-prices {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.plan-option-price {
+  font-weight: 800;
+  font-size: 0.95rem;
+  color: #10b981;
+}
+
+.plan-option-price small {
+  font-weight: 500;
+  font-size: 0.75rem;
+  color: var(--cabania-text-muted, #94a3b8);
+}
+
+.plan-option-price.child {
+  color: #0ea5e9;
+}
+
+.plan-option-schedule {
+  font-size: 0.8rem;
+  color: var(--cabania-text-muted, #64748b);
+}
+
+/* Dark mode */
+:global([data-theme="dark"]) .plan-option-badge {
+  background: rgba(14, 165, 233, 0.15);
+  border-color: rgba(14, 165, 233, 0.25);
+  color: #7dd3fc;
+}
+</style>

--- a/src/components/public/BookingStepResult.vue
+++ b/src/components/public/BookingStepResult.vue
@@ -1,0 +1,288 @@
+<template>
+  <div class="step-result">
+    <!-- Loading -->
+    <div v-if="loading" class="result-loading">
+      <div class="loading-spinner"></div>
+      <p>Consultando disponibilidad...</p>
+    </div>
+
+    <!-- Available -->
+    <div v-else-if="result?.is_available" class="result-card available">
+      <div class="result-icon">&#10003;</div>
+      <h4 class="result-title">Disponible</h4>
+      <p class="result-dates">
+        {{ formatDate(result.check_in) }}
+        <template v-if="result.check_out !== result.check_in">
+          &rarr; {{ formatDate(result.check_out) }}
+        </template>
+      </p>
+      <div v-if="result.suitable_plans?.length" class="result-plans">
+        <div v-for="sp in result.suitable_plans" :key="sp.id" class="result-plan-row">
+          <span class="result-plan-name">{{ sp.name }}</span>
+          <span class="result-plan-total">{{ formatCurrency(sp.estimated_total) }}</span>
+        </div>
+      </div>
+      <p v-else class="result-no-plans">
+        No hay planes disponibles para {{ result.total_guests }} persona(s).
+      </p>
+      <button class="continue-btn" @click="$emit('continue')">Continuar</button>
+    </div>
+
+    <!-- Not available -->
+    <div v-else-if="result" class="result-card unavailable">
+      <div class="result-icon unavailable-icon">&#10007;</div>
+      <h4 class="result-title">No disponible</h4>
+      <p class="result-dates">
+        {{ formatDate(result.check_in) }}
+        <template v-if="result.check_out !== result.check_in">
+          &rarr; {{ formatDate(result.check_out) }}
+        </template>
+      </p>
+      <div v-if="result.next_available_dates?.length" class="alt-dates">
+        <p class="alt-dates-label">Fechas cercanas disponibles:</p>
+        <div class="alt-date-chips">
+          <button
+            v-for="d in result.next_available_dates"
+            :key="d.date"
+            class="alt-date-chip"
+            @click="$emit('pick-alt-date', d.date)"
+          >
+            {{ formatShortDate(d.date) }}
+            <small>{{ d.day_of_week }}</small>
+          </button>
+        </div>
+      </div>
+      <button class="retry-btn" @click="$emit('back')">Cambiar fechas</button>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="errorMsg" class="result-card error-card">
+      <p class="error-text">{{ errorMsg }}</p>
+      <button class="retry-btn" @click="$emit('back')">Intentar de nuevo</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  loading: { type: Boolean, default: false },
+  result: { type: Object, default: null },
+  errorMsg: { type: String, default: '' }
+})
+
+defineEmits(['continue', 'back', 'pick-alt-date'])
+
+const formatCurrency = (value) => {
+  return new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value)
+}
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return ''
+  const d = new Date(dateStr + 'T12:00:00')
+  return d.toLocaleDateString('es-CO', { weekday: 'short', day: 'numeric', month: 'short' })
+}
+
+const formatShortDate = (dateStr) => {
+  if (!dateStr) return ''
+  const d = new Date(dateStr + 'T12:00:00')
+  return d.toLocaleDateString('es-CO', { day: 'numeric', month: 'short' })
+}
+</script>
+
+<style scoped>
+.step-result {
+  padding: 0.75rem;
+}
+
+.result-loading {
+  text-align: center;
+  padding: 2rem 0;
+  color: var(--cabania-text-muted, #64748b);
+}
+
+.loading-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(16, 185, 129, 0.2);
+  border-top-color: #10b981;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin: 0 auto 0.5rem;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.result-card {
+  border-radius: 14px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.result-card.available {
+  background: rgba(16, 185, 129, 0.06);
+  border: 1.5px solid rgba(16, 185, 129, 0.2);
+}
+
+.result-card.unavailable {
+  background: rgba(245, 158, 11, 0.06);
+  border: 1.5px solid rgba(245, 158, 11, 0.2);
+}
+
+.result-card.error-card {
+  background: rgba(239, 68, 68, 0.06);
+  border: 1.5px solid rgba(239, 68, 68, 0.2);
+}
+
+.result-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  font-weight: 800;
+  margin-bottom: 0.5rem;
+  background: rgba(16, 185, 129, 0.15);
+  color: #059669;
+}
+
+.result-icon.unavailable-icon {
+  background: rgba(245, 158, 11, 0.15);
+  color: #d97706;
+}
+
+.result-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--cabania-text, #0f172a);
+}
+
+.result-dates {
+  font-size: 0.9rem;
+  color: var(--cabania-text-muted, #64748b);
+  margin: 0 0 0.75rem;
+}
+
+.result-plans {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.result-plan-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4rem 0.6rem;
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.65));
+  border-radius: 8px;
+}
+
+.result-plan-name {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--cabania-text, #0f172a);
+}
+
+.result-plan-total {
+  font-weight: 800;
+  font-size: 0.95rem;
+  color: #10b981;
+}
+
+.result-no-plans {
+  font-size: 0.85rem;
+  color: var(--cabania-text-muted, #64748b);
+  margin: 0 0 0.75rem;
+}
+
+.alt-dates {
+  margin: 0.75rem 0;
+}
+
+.alt-dates-label {
+  font-size: 0.8rem;
+  color: var(--cabania-text-muted, #64748b);
+  margin: 0 0 0.4rem;
+}
+
+.alt-date-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: center;
+}
+
+.alt-date-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.35rem 0.65rem;
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.75));
+  border: 1.5px solid var(--cabania-border, rgba(0, 0, 0, 0.08));
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--cabania-text, #0f172a);
+  transition: border-color 0.2s, transform 0.15s;
+}
+
+.alt-date-chip small {
+  font-size: 0.65rem;
+  font-weight: 500;
+  color: var(--cabania-text-muted, #94a3b8);
+  text-transform: capitalize;
+}
+
+.alt-date-chip:hover {
+  border-color: #10b981;
+  transform: translateY(-1px);
+}
+
+.continue-btn {
+  width: 100%;
+  padding: 0.65rem;
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.15s;
+  box-shadow: 0 4px 16px rgba(16, 185, 129, 0.25);
+}
+
+.continue-btn:hover {
+  transform: translateY(-1px);
+}
+
+.retry-btn {
+  width: 100%;
+  padding: 0.55rem;
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.65));
+  border: 1.5px solid var(--cabania-border, rgba(0, 0, 0, 0.12));
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--cabania-text, #0f172a);
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.retry-btn:hover {
+  border-color: #10b981;
+}
+
+.error-text {
+  color: #dc2626;
+  font-size: 0.9rem;
+  margin: 0 0 0.75rem;
+}
+</style>

--- a/src/components/public/ChatBubbleWidget.vue
+++ b/src/components/public/ChatBubbleWidget.vue
@@ -1,0 +1,583 @@
+<template>
+  <!-- Floating bubble button -->
+  <button :class="['chat-bubble-btn', { 'is-open': isOpen }]" @click="togglePanel">
+    <svg v-if="!isOpen" viewBox="0 0 24 24" fill="none" width="48" height="48" style="margin-top: 4px">
+      <!-- Chat bubble outline -->
+      <path d="M3 4.5A2.5 2.5 0 0 1 5.5 2h13A2.5 2.5 0 0 1 21 4.5v9a2.5 2.5 0 0 1-2.5 2.5H14l-2 3-2-3H5.5A2.5 2.5 0 0 1 3 13.5v-9z" stroke="currentColor" stroke-width="0.8" stroke-linejoin="round"/>
+      <!-- CabanIA cabin icon from logo -->
+      <g transform="translate(-1.69, 1.98) scale(0.009)" fill="currentColor">
+        <polygon points="1522.1,316.1 924.8,911.3 992.7,911.3 1521.6,384.9 2051.3,911.3 2118.3,911.3"/>
+        <path d="M1948.8,926.2h56.7l-483.5-482.8l-482.4,482.8h54.7v317.6h-87.5v49.9h1030.8v-47.8h-88.9V926.2z M1541.7,529.1L1890.6,878h-176.7l-172.3-236.5V529.1z M1665.8,878.2h-288.5l144.3-199.5L1665.8,878.2z M1502.7,529.1v111.5l-172.9,237.6h-176L1502.7,529.1z M1267.7,1243.6H1144v-81.9l71.2-73.5V1015 c10.3-3.8,17.7-13.8,17.7-25.5c0-15-12.2-27.1-27.1-27.1c-15,0-27.1,12.2-27.1,27.1c0,11.8,7.6,21.9,18.2,25.6v65.6 L1144,1133V927.2h123.6V1243.6z M1205.8,1000.7c-6.1,0-11.1-5-11.1-11.1c0-6.2,5-11.1,11.1-11.1c6.1,0,11.1,5,11.1,11.1 C1217,995.7,1212,1000.7,1205.8,1000.7z M1727.9,1243h-412.6v-39.2h181.1c4,10.1,13.8,17.2,25.2,17.2 c15,0,27.1-12.2,27.1-27.1c0-15-12.2-27.1-27.1-27.1c-11.7,0-21.7,7.4-25.5,17.8h-180.8v-257h412.6V1243z M1510.6,1193.8c0-6.1,5-11.1,11.1-11.1c6.1,0,11.1,5,11.1,11.1c0,6.2-5,11.1-11.1,11.1 C1515.6,1205,1510.6,1200,1510.6,1193.8z M1900.6,1133.6l-52.8-52.8V1014 c10.3-3.8,17.6-13.8,17.6-25.4c0-15-12.2-27.1-27.1-27.1s-27.1,12.2-27.1,27.1 c0,11.7,7.5,21.8,17.9,25.5v74.3l71.5,73.1v82.5H1776V927.5h124.6V1133.6z M1838.3,999.7c-6.1,0-11.1-5-11.1-11.1c0-6.2,5-11.1,11.1-11.1s11.1,5,11.1,11.1 C1849.4,994.7,1844.4,999.7,1838.3,999.7z"/>
+      </g>
+    </svg>
+    <svg v-else viewBox="0 0 24 24" fill="none" width="20" height="20">
+      <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+    </svg>
+  </button>
+
+  <!-- Panel -->
+  <Transition name="chat-panel">
+    <div v-if="isOpen" class="chat-panel">
+      <!-- Header -->
+      <div class="chat-panel-header">
+        <div class="header-left">
+          <span class="header-name">{{ venue?.name || 'Chat' }}</span>
+        </div>
+        <div class="header-right">
+          <button class="header-close" @click="isOpen = false">✕</button>
+        </div>
+      </div>
+
+      <!-- Contact Form -->
+      <ChatContactForm
+        v-if="chatState === 'contact_form'"
+        :venue-name="venue?.name"
+        @submit="onContactSubmit"
+      />
+
+      <!-- Chat Area -->
+      <template v-if="chatState === 'chatting' || chatState === 'limit_reached'">
+        <ChatMessages
+          ref="messagesRef"
+          :messages="messages"
+          :sending="sending"
+          :venue-name="venue?.name"
+          :visitor-name="visitor.name"
+        />
+
+        <!-- Limit banner -->
+        <div v-if="chatState === 'limit_reached'" class="limit-banner">
+          <p>Has alcanzado el límite de {{ freeLimit }} mensajes gratuitos.</p>
+          <button class="limit-verify-btn" @click="chatState = 'verifying'">
+            Verificar mi número para seguir
+          </button>
+        </div>
+
+        <ChatInput
+          v-else
+          ref="inputRef"
+          :sending="sending"
+          :disabled="chatState === 'limit_reached'"
+          @send="onSendMessage"
+        />
+      </template>
+
+      <!-- Verification -->
+      <ChatVerification
+        v-if="chatState === 'verifying'"
+        :initial-phone="visitor.contactType === 'whatsapp' ? visitor.contactValue : ''"
+        :conversation-id="conversationId"
+        @verified="onVerified"
+      />
+
+      <!-- Loading state for restoring conversation -->
+      <div v-if="chatState === 'loading'" class="chat-loading">
+        <div class="loading-spinner"></div>
+        <p>Cargando conversación...</p>
+      </div>
+
+      <!-- Footer -->
+      <div class="chat-panel-footer">
+        <span class="footer-text">Powered by</span>
+        <img src="/logo-inverted.svg" alt="CabanIA" class="footer-logo-icon" />
+        <img src="/logo-wordmark.svg" alt="CabanIA" class="footer-logo-wordmark" />
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted, onUnmounted, nextTick, watch } from 'vue'
+import ChatContactForm from './ChatContactForm.vue'
+import ChatMessages from './ChatMessages.vue'
+import ChatInput from './ChatInput.vue'
+import ChatVerification from './ChatVerification.vue'
+
+const props = defineProps({
+  venue: { type: Object, default: null },
+  venueId: { type: String, required: true }
+})
+
+const isOpen = ref(false)
+const chatState = ref('contact_form') // contact_form | loading | chatting | limit_reached | verifying
+const messages = ref([])
+const sending = ref(false)
+const conversationId = ref(null)
+const freeLimit = ref(20)
+const messageCount = ref(0)
+const messagesRef = ref(null)
+const inputRef = ref(null)
+
+const visitor = reactive({
+  name: '',
+  contactType: 'whatsapp',
+  contactValue: '',
+  verified: false
+})
+
+const STORAGE_KEY = `cabania-chat-${props.venueId}`
+
+// --- localStorage helpers ---
+const loadStorage = () => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) return JSON.parse(raw)
+    // Migrate from legacy sessionStorage
+    const legacy = sessionStorage.getItem(`public-chat-${props.venueId}`)
+    if (legacy) {
+      sessionStorage.removeItem(`public-chat-${props.venueId}`)
+      return { conversationId: legacy }
+    }
+  } catch {}
+  return null
+}
+
+const saveStorage = () => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      conversationId: conversationId.value,
+      visitor: { name: visitor.name, contactType: visitor.contactType, contactValue: visitor.contactValue },
+      messageCount: messageCount.value,
+      verified: visitor.verified,
+      lastActivity: new Date().toISOString()
+    }))
+  } catch {}
+}
+
+// --- Restore conversation ---
+const restoreConversation = async (convId) => {
+  chatState.value = 'loading'
+  try {
+    const res = await fetch(`/api/public/chat/conversation/${convId}`)
+    if (!res.ok) {
+      chatState.value = 'contact_form'
+      return
+    }
+    const data = await res.json()
+    conversationId.value = data.id
+    messages.value = data.messages.map(m => ({ role: m.role, content: m.content }))
+    messageCount.value = data.message_count
+    freeLimit.value = data.free_limit
+    visitor.verified = data.is_verified
+
+    if (data.name) visitor.name = data.name
+
+    if (!visitor.verified && messageCount.value >= freeLimit.value) {
+      chatState.value = 'limit_reached'
+    } else {
+      chatState.value = 'chatting'
+    }
+    saveStorage()
+  } catch {
+    chatState.value = 'contact_form'
+  }
+}
+
+// --- Event handlers ---
+const onContactSubmit = (data) => {
+  visitor.name = data.name
+  visitor.contactType = data.contactType
+  visitor.contactValue = data.contactValue
+  chatState.value = 'chatting'
+  saveStorage()
+  nextTick(() => inputRef.value?.focus())
+}
+
+const onSendMessage = async (text) => {
+  if (!text.trim() || sending.value) return
+
+  messages.value.push({ role: 'user', content: text })
+  sending.value = true
+
+  try {
+    const body = {
+      message: text,
+      conversation_id: conversationId.value,
+      source: 'web',
+      contact_type: visitor.contactType,
+      contact_value: visitor.contactValue,
+      visitor_name: visitor.name,
+      visitor_phone: visitor.contactType === 'whatsapp' ? visitor.contactValue : undefined
+    }
+
+    const res = await fetch(`/api/chat/${props.venueId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+
+    const result = await res.json()
+
+    if (res.status === 403 && result.error === 'free_limit_reached') {
+      messageCount.value = result.message_count
+      freeLimit.value = result.free_limit
+      chatState.value = 'limit_reached'
+      // Remove the user message that wasn't processed
+      messages.value.pop()
+      saveStorage()
+      return
+    }
+
+    if (res.ok) {
+      if (result.conversation_id) {
+        conversationId.value = result.conversation_id
+      }
+
+      let content = result.message || result.response || ''
+      content = content.replace(/\n<!-- \{.*?\} -->/g, '')
+      messages.value.push({ role: 'assistant', content })
+
+      if (result.message_count !== undefined) {
+        messageCount.value = result.message_count
+      }
+      if (result.free_limit !== undefined) {
+        freeLimit.value = result.free_limit
+      }
+      if (result.is_verified) {
+        visitor.verified = true
+      }
+
+      saveStorage()
+    } else {
+      messages.value.push({ role: 'assistant', content: 'Lo siento, no pude procesar tu mensaje. Intenta de nuevo.' })
+    }
+  } catch (err) {
+    console.error('Chat send error:', err)
+    messages.value.push({ role: 'assistant', content: 'Error de conexión. Intenta de nuevo.' })
+  } finally {
+    sending.value = false
+  }
+}
+
+const onVerified = () => {
+  visitor.verified = true
+  chatState.value = 'chatting'
+  saveStorage()
+  nextTick(() => inputRef.value?.focus())
+}
+
+// --- Public method: askQuestion (called from plan "Preguntar disponibilidad") ---
+const askQuestion = (text) => {
+  isOpen.value = true
+  if (chatState.value === 'contact_form') {
+    pendingQuestion.value = text
+    return
+  }
+  // Use setTimeout to allow Transition to finish rendering the panel
+  setTimeout(() => {
+    inputRef.value?.setMessage(text)
+    onSendMessage(text)
+  }, 150)
+}
+const pendingQuestion = ref('')
+
+// Watch for transition from contact_form to chatting to send pending question
+watch(chatState, (newState) => {
+  if (newState === 'chatting' && pendingQuestion.value) {
+    const q = pendingQuestion.value
+    pendingQuestion.value = ''
+    nextTick(() => onSendMessage(q))
+  }
+})
+
+const togglePanel = () => {
+  isOpen.value = !isOpen.value
+}
+
+// --- Public method: startBookingChat (called after booking wizard completes) ---
+const startBookingChat = (context) => {
+  // Set visitor data from booking context (skips contact form)
+  visitor.name = context.name
+  visitor.contactType = context.contactType
+  visitor.contactValue = context.contactValue
+
+  if (chatState.value === 'contact_form') {
+    chatState.value = 'chatting'
+  }
+  saveStorage()
+
+  // Build pre-formatted booking message
+  const checkOut = context.checkOut && context.checkOut !== context.checkIn ? ` al ${context.checkOut}` : ''
+  const childrenText = context.children ? `, ${context.children} niño(s)` : ''
+  const totalText = context.estimatedTotal
+    ? ` (estimado: ${new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(context.estimatedTotal)})`
+    : ''
+  const msg = `Hola, quisiera reservar el plan "${context.plan.name}" para el ${context.checkIn}${checkOut}, ${context.adults} adulto(s)${childrenText}${totalText}. Mi nombre es ${context.name}.`
+
+  // Open panel and send message
+  isOpen.value = true
+  setTimeout(() => onSendMessage(msg), 200)
+}
+
+defineExpose({ askQuestion, startBookingChat })
+
+// --- Init ---
+onMounted(() => {
+  const stored = loadStorage()
+  if (stored) {
+    if (stored.visitor) {
+      visitor.name = stored.visitor.name || ''
+      visitor.contactType = stored.visitor.contactType || 'whatsapp'
+      visitor.contactValue = stored.visitor.contactValue || ''
+    }
+    visitor.verified = stored.verified || false
+    messageCount.value = stored.messageCount || 0
+
+    if (stored.conversationId) {
+      conversationId.value = stored.conversationId
+      // Will restore on first open
+    }
+
+    if (stored.visitor?.name) {
+      chatState.value = 'chatting' // Has contact info, go straight to chat
+    }
+  }
+})
+
+// Lazy-load conversation when panel opens for the first time with a stored conversationId
+const hasRestored = ref(false)
+watch(isOpen, async (open) => {
+  // Toggle body class for mobile header hiding
+  document.body.classList.toggle('chat-panel-open', open)
+  if (open && !hasRestored.value && conversationId.value) {
+    hasRestored.value = true
+    await restoreConversation(conversationId.value)
+  }
+})
+
+onUnmounted(() => {
+  document.body.classList.remove('chat-panel-open')
+})
+</script>
+
+<style scoped>
+/* Bubble button */
+.chat-bubble-btn {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  border: none;
+  color: white;
+  font-size: 1.5rem;
+  cursor: pointer;
+  box-shadow: 0 4px 16px rgba(16, 185, 129, 0.35);
+  z-index: 10003;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.chat-bubble-btn:hover {
+  transform: scale(1.08);
+  box-shadow: 0 6px 20px rgba(16, 185, 129, 0.45);
+}
+
+.chat-bubble-btn.is-open {
+  background: #64748b;
+  box-shadow: 0 4px 12px rgba(100, 116, 139, 0.3);
+}
+
+/* Panel */
+.chat-panel {
+  position: fixed;
+  bottom: 5.5rem;
+  right: 1.5rem;
+  width: 380px;
+  max-width: calc(100vw - 2rem);
+  max-height: 70vh;
+  background: var(--cabania-surface-bg, rgba(255, 255, 255, 0.85));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--cabania-border, rgba(0, 0, 0, 0.08));
+  border-radius: 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(255,255,255,0.1) inset;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 10004;
+}
+
+/* Panel header */
+.chat-panel-header {
+  padding: 0.6rem 0.85rem;
+  background: var(--cabania-card-bg, rgba(255, 255, 255, 0.65));
+  border-bottom: 1px solid var(--cabania-border-subtle, rgba(0, 0, 0, 0.05));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  flex-shrink: 0;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.header-name {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--cabania-text, #0f172a);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.header-close {
+  background: none;
+  border: none;
+  font-size: 1rem;
+  cursor: pointer;
+  color: var(--cabania-text-muted, #64748b);
+  padding: 0.25rem;
+  line-height: 1;
+  border-radius: 50%;
+  transition: background 0.2s;
+}
+
+.header-close:hover {
+  background: var(--cabania-hover-bg, rgba(0, 0, 0, 0.03));
+}
+
+/* Panel footer */
+.chat-panel-footer {
+  padding: 0.4rem 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border-top: 1px solid var(--cabania-border-subtle, rgba(0, 0, 0, 0.05));
+  flex-shrink: 0;
+}
+
+.footer-text {
+  font-size: 0.7rem;
+  color: var(--cabania-text-muted, #94a3b8);
+}
+
+.footer-logo-icon {
+  height: 14px;
+  width: 14px;
+  border-radius: 0.2rem;
+  object-fit: contain;
+  opacity: 0.6;
+}
+
+.footer-logo-wordmark {
+  height: 12px;
+  width: auto;
+  opacity: 0.5;
+}
+
+/* Limit banner */
+.limit-banner {
+  padding: 0.85rem 1rem;
+  background: rgba(245, 158, 11, 0.08);
+  border-top: 1px solid rgba(245, 158, 11, 0.2);
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.limit-banner p {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  color: #92400e;
+}
+
+.limit-verify-btn {
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.limit-verify-btn:hover {
+  opacity: 0.9;
+}
+
+/* Loading */
+.chat-loading {
+  padding: 2rem;
+  text-align: center;
+  color: var(--cabania-text-muted, #64748b);
+}
+
+.loading-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(16, 185, 129, 0.2);
+  border-top-color: #10b981;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin: 0 auto 0.5rem;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Panel transitions */
+.chat-panel-enter-active {
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.chat-panel-leave-active {
+  transition: all 0.2s ease-in;
+}
+
+.chat-panel-enter-from {
+  opacity: 0;
+  transform: translateY(1rem) scale(0.95);
+}
+
+.chat-panel-leave-to {
+  opacity: 0;
+  transform: translateY(0.5rem) scale(0.98);
+}
+
+/* Mobile */
+@media (max-width: 640px) {
+  .chat-bubble-btn {
+    bottom: 1rem;
+    right: 1rem;
+    width: 50px;
+    height: 50px;
+    font-size: 1.3rem;
+  }
+
+  .chat-panel {
+    bottom: 4.5rem;
+    right: 0.75rem;
+    left: 0.75rem;
+    width: auto;
+    max-height: 75vh;
+    border-radius: 1rem;
+  }
+}
+
+/* Hide page header on mobile when chat is open */
+@media (max-width: 640px) {
+  :global(body.chat-panel-open .public-header) {
+    display: none;
+  }
+}
+</style>

--- a/src/components/public/ChatContactForm.vue
+++ b/src/components/public/ChatContactForm.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="chat-contact-form">
+    <div class="form-header">
+      <h4>Antes de empezar</h4>
+      <p>Ingresa tu nombre y un medio de contacto para poder atenderte mejor.</p>
+    </div>
+    <form @submit.prevent="handleSubmit">
+      <div class="form-field">
+        <label>Nombre *</label>
+        <input
+          v-model="name"
+          type="text"
+          placeholder="Tu nombre"
+          required
+          class="field-input"
+        />
+      </div>
+      <div class="form-field">
+        <label>Medio de contacto *</label>
+        <div class="contact-toggle">
+          <button
+            type="button"
+            :class="['toggle-btn', { active: contactType === 'whatsapp' }]"
+            @click="contactType = 'whatsapp'"
+          >
+            WhatsApp
+          </button>
+          <button
+            type="button"
+            :class="['toggle-btn', { active: contactType === 'instagram' }]"
+            @click="contactType = 'instagram'"
+          >
+            Instagram
+          </button>
+        </div>
+        <input
+          v-model="contactValue"
+          :type="contactType === 'whatsapp' ? 'tel' : 'text'"
+          :placeholder="contactType === 'whatsapp' ? 'Ej: 3001234567' : 'Ej: @tuusuario'"
+          required
+          class="field-input"
+        />
+      </div>
+      <button type="submit" class="submit-btn" :disabled="!isValid">
+        Iniciar chat
+      </button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+defineProps({ venueName: String })
+const emit = defineEmits(['submit'])
+
+const name = ref('')
+const contactType = ref('whatsapp')
+const contactValue = ref('')
+
+const isValid = computed(() => {
+  return name.value.trim().length > 0 && contactValue.value.trim().length > 0
+})
+
+const handleSubmit = () => {
+  if (!isValid.value) return
+  emit('submit', {
+    name: name.value.trim(),
+    contactType: contactType.value,
+    contactValue: contactValue.value.trim()
+  })
+}
+</script>
+
+<style scoped>
+.chat-contact-form {
+  padding: 1.25rem;
+}
+
+.form-header h4 {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--cabania-text, #0f172a);
+}
+
+.form-header p {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: var(--cabania-text-muted, #64748b);
+}
+
+.form-field {
+  margin-bottom: 0.85rem;
+}
+
+.form-field label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--cabania-text-secondary, #475569);
+  margin-bottom: 0.3rem;
+}
+
+.field-input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--cabania-border, rgba(0,0,0,0.08));
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  background: var(--cabania-input-bg, rgba(255,255,255,0.6));
+  color: var(--cabania-text, #0f172a);
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  box-sizing: border-box;
+}
+
+.field-input:focus {
+  border-color: var(--cabania-focus-border, rgba(14,165,233,0.4));
+  box-shadow: 0 0 0 3px rgba(14,165,233,0.1);
+}
+
+.contact-toggle {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.toggle-btn {
+  flex: 1;
+  padding: 0.4rem;
+  border: 1.5px solid var(--cabania-border, rgba(0,0,0,0.08));
+  border-radius: 0.5rem;
+  background: transparent;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--cabania-text-muted, #64748b);
+  transition: all 0.2s;
+}
+
+.toggle-btn.active {
+  background: rgba(16, 185, 129, 0.08);
+  border-color: rgba(16, 185, 129, 0.3);
+  color: #059669;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 0.65rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.15s;
+}
+
+.submit-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.submit-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/public/ChatInput.vue
+++ b/src/components/public/ChatInput.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="chat-input-bar">
+    <input
+      ref="inputEl"
+      v-model="text"
+      type="text"
+      :placeholder="placeholder"
+      :disabled="disabled || sending"
+      class="chat-input-field"
+      @keyup.enter="handleSend"
+    />
+    <button
+      class="chat-send-btn"
+      :disabled="disabled || sending || !text.trim()"
+      @click="handleSend"
+    >
+      <span v-if="sending" class="send-dots">...</span>
+      <span v-else>➤</span>
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  disabled: Boolean,
+  sending: Boolean,
+  placeholder: { type: String, default: 'Escribe tu pregunta...' }
+})
+
+const emit = defineEmits(['send'])
+const text = ref('')
+const inputEl = ref(null)
+
+const handleSend = () => {
+  if (!text.value.trim() || props.disabled || props.sending) return
+  emit('send', text.value.trim())
+  text.value = ''
+}
+
+const focus = () => {
+  inputEl.value?.focus()
+}
+
+const setMessage = (msg) => {
+  text.value = msg
+}
+
+defineExpose({ focus, setMessage })
+</script>
+
+<style scoped>
+.chat-input-bar {
+  display: flex;
+  border-top: 1px solid var(--cabania-border-subtle, rgba(0,0,0,0.05));
+  background: var(--cabania-card-bg, rgba(255,255,255,0.65));
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-radius: 0 0 1.5rem 1.5rem;
+  overflow: hidden;
+}
+
+.chat-input-field {
+  flex: 1;
+  border: none;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  outline: none;
+  background: transparent;
+  color: var(--cabania-text, #0f172a);
+}
+
+.chat-input-field::placeholder {
+  color: var(--cabania-text-dim, #94a3b8);
+}
+
+.chat-send-btn {
+  border: none;
+  background: #10b981;
+  color: #fff;
+  padding: 0 1rem;
+  font-size: 1.15rem;
+  cursor: pointer;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+}
+
+.chat-send-btn:hover:not(:disabled) {
+  background: #059669;
+}
+
+.chat-send-btn:disabled {
+  background: #cbd5e1;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .chat-input-bar {
+    border-radius: 0 0 1rem 1rem;
+  }
+}
+</style>

--- a/src/components/public/ChatMessages.vue
+++ b/src/components/public/ChatMessages.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="chat-messages" ref="container">
+    <div v-if="messages.length === 0" class="chat-empty">
+      <p>👋 ¡Hola, <strong>{{ visitorName }}</strong>!</p>
+      <p class="text-muted">Pregúntame lo que quieras sobre <strong>{{ venueName }}</strong>.</p>
+    </div>
+    <div
+      v-for="(msg, idx) in messages"
+      :key="idx"
+      :class="['msg-row', msg.role === 'user' ? 'msg-user' : 'msg-bot']"
+    >
+      <div :class="['msg-bubble', msg.role === 'user' ? 'bubble-user' : 'bubble-bot']">
+        <div class="msg-text" v-html="formatMessage(msg.content)"></div>
+      </div>
+    </div>
+    <div v-if="sending" class="msg-row msg-bot">
+      <div class="msg-bubble bubble-bot typing">
+        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, nextTick, onMounted } from 'vue'
+
+const props = defineProps({
+  messages: { type: Array, default: () => [] },
+  sending: Boolean,
+  venueName: String,
+  visitorName: { type: String, default: '' }
+})
+
+const container = ref(null)
+
+const formatMessage = (text) => {
+  if (!text) return ''
+  return text
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\n/g, '<br>')
+}
+
+const scrollToBottom = async () => {
+  await nextTick()
+  if (container.value) {
+    container.value.scrollTop = container.value.scrollHeight
+  }
+}
+
+watch(() => props.messages.length, scrollToBottom)
+watch(() => props.sending, scrollToBottom)
+onMounted(scrollToBottom)
+
+defineExpose({ scrollToBottom })
+</script>
+
+<style scoped>
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem;
+  min-height: 0;
+}
+
+.chat-empty {
+  text-align: center;
+  padding: 2rem 0.5rem;
+  color: var(--cabania-text-secondary, #475569);
+  font-size: 0.9rem;
+}
+
+.chat-empty p {
+  margin: 0.2rem 0;
+}
+
+.chat-empty .text-muted {
+  color: var(--cabania-text-muted, #64748b);
+  font-size: 0.85rem;
+}
+
+.msg-row {
+  display: flex;
+  margin-bottom: 0.6rem;
+}
+
+.msg-user { justify-content: flex-end; }
+.msg-bot { justify-content: flex-start; }
+
+.msg-bubble {
+  max-width: 85%;
+  padding: 0.55rem 0.85rem;
+  border-radius: 14px;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.bubble-user {
+  background: #10b981;
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+
+.bubble-bot {
+  background: var(--cabania-card-bg, rgba(255,255,255,0.65));
+  color: var(--cabania-text, #1e293b);
+  border: 1px solid var(--cabania-border, rgba(0,0,0,0.08));
+  border-bottom-left-radius: 4px;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.msg-text { word-break: break-word; }
+
+/* Typing indicator */
+.typing {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  padding: 0.7rem 1rem;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  background: #94a3b8;
+  border-radius: 50%;
+  animation: dotPulse 1.2s infinite ease-in-out;
+}
+
+.dot:nth-child(2) { animation-delay: 0.2s; }
+.dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes dotPulse {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+</style>

--- a/src/components/public/ChatVerification.vue
+++ b/src/components/public/ChatVerification.vue
@@ -1,0 +1,332 @@
+<template>
+  <div class="verification-view">
+    <div v-if="step === 'confirm'" class="verify-step">
+      <h4>Verificación requerida</h4>
+      <p>Has alcanzado el límite de mensajes gratuitos. Confirma tu número para seguir chateando.</p>
+      <div class="phone-field">
+        <label>Número de WhatsApp</label>
+        <input
+          v-model="phone"
+          type="tel"
+          placeholder="3001234567"
+          class="field-input"
+        />
+      </div>
+      <button
+        class="verify-btn"
+        :disabled="!phone.trim() || requesting"
+        @click="requestCode"
+      >
+        {{ requesting ? 'Enviando...' : 'Enviar código de verificación' }}
+      </button>
+      <p v-if="requestError" class="error-text">{{ requestError }}</p>
+    </div>
+
+    <div v-else-if="step === 'code'" class="verify-step">
+      <h4>Ingresa el código</h4>
+      <p>Se envió un código de 6 dígitos al <strong>{{ phone }}</strong></p>
+      <div class="code-input-group">
+        <input
+          v-for="i in 6"
+          :key="i"
+          ref="codeInputs"
+          v-model="codeDigits[i - 1]"
+          type="text"
+          maxlength="1"
+          inputmode="numeric"
+          class="code-digit"
+          @input="onDigitInput(i - 1)"
+          @keydown.backspace="onBackspace(i - 1, $event)"
+          @paste.prevent="onPaste"
+        />
+      </div>
+      <button class="paste-btn" @click="pasteFromClipboard">
+        📋 Pegar código
+      </button>
+      <div class="code-actions">
+        <button
+          class="verify-btn"
+          :disabled="fullCode.length < 6 || confirming"
+          @click="confirmCode"
+        >
+          {{ confirming ? 'Verificando...' : 'Verificar' }}
+        </button>
+      </div>
+      <p v-if="codeError" class="error-text">{{ codeError }}</p>
+      <p v-if="expiresIn > 0" class="timer-text">
+        Código expira en {{ Math.floor(expiresIn / 60) }}:{{ String(expiresIn % 60).padStart(2, '0') }}
+      </p>
+      <button class="link-btn" @click="step = 'confirm'">Cambiar número o reenviar código</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+
+const props = defineProps({
+  initialPhone: { type: String, default: '' },
+  conversationId: { type: String, required: true }
+})
+
+const emit = defineEmits(['verified', 'cancel'])
+
+const step = ref('confirm')
+const phone = ref(props.initialPhone)
+const requesting = ref(false)
+const requestError = ref('')
+const confirming = ref(false)
+const codeError = ref('')
+const codeDigits = ref(['', '', '', '', '', ''])
+const codeInputs = ref([])
+const expiresIn = ref(0)
+let timerInterval = null
+
+const fullCode = computed(() => codeDigits.value.join(''))
+
+const requestCode = async () => {
+  if (!phone.value.trim()) return
+  requesting.value = true
+  requestError.value = ''
+
+  try {
+    const res = await fetch('/api/public/chat/verify/request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        conversation_id: props.conversationId,
+        phone: phone.value.trim()
+      })
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      requestError.value = data.error || 'Error al solicitar código'
+      return
+    }
+    // Dev mode: auto-fill code for testing
+    if (data.code) {
+      const digits = data.code.split('')
+      codeDigits.value = digits
+    }
+    step.value = 'code'
+    expiresIn.value = 600 // 10 minutes
+    startTimer()
+  } catch (err) {
+    requestError.value = 'Error de conexión'
+  } finally {
+    requesting.value = false
+  }
+}
+
+const confirmCode = async () => {
+  if (fullCode.value.length < 6) return
+  confirming.value = true
+  codeError.value = ''
+
+  try {
+    const res = await fetch('/api/public/chat/verify/confirm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        conversation_id: props.conversationId,
+        code: fullCode.value
+      })
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      codeError.value = data.error || 'Error al verificar'
+      if (data.attempts_remaining !== undefined) {
+        codeError.value += ` (${data.attempts_remaining} intentos restantes)`
+      }
+      return
+    }
+    emit('verified')
+  } catch (err) {
+    codeError.value = 'Error de conexión'
+  } finally {
+    confirming.value = false
+  }
+}
+
+const onDigitInput = (idx) => {
+  const val = codeDigits.value[idx]
+  if (val && idx < 5 && codeInputs.value[idx + 1]) {
+    codeInputs.value[idx + 1].focus()
+  }
+}
+
+const onBackspace = (idx, event) => {
+  if (!codeDigits.value[idx] && idx > 0) {
+    codeInputs.value[idx - 1].focus()
+  }
+}
+
+const onPaste = (event) => {
+  const text = event.clipboardData.getData('text').replace(/\D/g, '').slice(0, 6)
+  if (text.length > 0) {
+    codeDigits.value = text.padEnd(6, '').split('').slice(0, 6)
+  }
+}
+
+const pasteFromClipboard = async () => {
+  try {
+    const text = await navigator.clipboard.readText()
+    const digits = text.replace(/\D/g, '').slice(0, 6)
+    if (digits.length > 0) {
+      codeDigits.value = digits.padEnd(6, '').split('').slice(0, 6)
+    }
+  } catch (err) {
+    // Clipboard API may not be available
+  }
+}
+
+const startTimer = () => {
+  if (timerInterval) clearInterval(timerInterval)
+  timerInterval = setInterval(() => {
+    if (expiresIn.value > 0) {
+      expiresIn.value--
+    } else {
+      clearInterval(timerInterval)
+    }
+  }, 1000)
+}
+
+onUnmounted(() => {
+  if (timerInterval) clearInterval(timerInterval)
+})
+</script>
+
+<style scoped>
+.verification-view {
+  padding: 1.25rem;
+}
+
+.verify-step h4 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--cabania-text, #0f172a);
+}
+
+.verify-step p {
+  font-size: 0.85rem;
+  color: var(--cabania-text-secondary, #475569);
+  margin: 0 0 0.75rem;
+}
+
+.phone-field {
+  margin-bottom: 0.85rem;
+}
+
+.phone-field label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--cabania-text-secondary, #475569);
+  margin-bottom: 0.3rem;
+}
+
+.field-input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--cabania-border, rgba(0,0,0,0.08));
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  background: var(--cabania-input-bg, rgba(255,255,255,0.6));
+  color: var(--cabania-text, #0f172a);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.field-input:focus {
+  border-color: var(--cabania-focus-border, rgba(14,165,233,0.4));
+  box-shadow: 0 0 0 3px rgba(14,165,233,0.1);
+}
+
+.code-input-group {
+  display: flex;
+  gap: 0.4rem;
+  justify-content: center;
+  margin-bottom: 0.75rem;
+}
+
+.code-digit {
+  width: 2.5rem;
+  height: 2.8rem;
+  text-align: center;
+  font-size: 1.25rem;
+  font-weight: 700;
+  border: 1.5px solid var(--cabania-border, rgba(0,0,0,0.08));
+  border-radius: 0.5rem;
+  background: var(--cabania-input-bg, rgba(255,255,255,0.6));
+  color: var(--cabania-text, #0f172a);
+  outline: none;
+}
+
+.code-digit:focus {
+  border-color: #10b981;
+  box-shadow: 0 0 0 3px rgba(16,185,129,0.15);
+}
+
+.paste-btn {
+  display: block;
+  margin: 0 auto 0.75rem;
+  border: 1px solid var(--cabania-border, rgba(0,0,0,0.08));
+  background: transparent;
+  color: var(--cabania-text-secondary, #475569);
+  padding: 0.35rem 0.85rem;
+  border-radius: 0.5rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.paste-btn:hover {
+  background: var(--cabania-hover-bg, rgba(0,0,0,0.03));
+}
+
+.code-actions {
+  margin-bottom: 0.5rem;
+}
+
+.verify-btn {
+  width: 100%;
+  padding: 0.6rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.verify-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error-text {
+  color: #ef4444;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.timer-text {
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--cabania-text-muted, #64748b);
+}
+
+.link-btn {
+  display: block;
+  margin: 0.25rem auto 0;
+  background: none;
+  border: none;
+  color: #0284c7;
+  font-size: 0.8rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+</style>

--- a/src/components/venues/VenueForm.vue
+++ b/src/components/venues/VenueForm.vue
@@ -253,6 +253,25 @@
       />
       <div class="form-text">Si está activo, esta cabaña aparecerá en la página pública de búsqueda de disponibilidad.</div>
     </div>
+    <div class="mb-3" v-if="form.is_public">
+      <CFormLabel for="venueSlug">URL Pública (slug)</CFormLabel>
+      <CInputGroup>
+        <CInputGroupText class="text-muted" style="font-size: 0.85rem;">cabaneroco.vercel.app/#/p/</CInputGroupText>
+        <CFormInput
+          id="venueSlug"
+          v-model="form.slug"
+          type="text"
+          placeholder="mi-cabana"
+          :pattern="'^[a-z0-9-]+$'"
+        />
+      </CInputGroup>
+      <div class="form-text">Identificador URL-friendly. Déjalo vacío para generarlo automáticamente desde el nombre.</div>
+      <div v-if="form.slug" class="form-text">
+        <a :href="publicVenueUrl" target="_blank">
+          Ver página pública ↗
+        </a>
+      </div>
+    </div>
     <CButton type="submit" color="primary" class="me-2">{{ isEdit ? 'Actualizar' : 'Crear' }}</CButton>
     <CButton color="secondary" variant="outline" @click="onCancel">Cancelar</CButton>
   </CForm>
@@ -293,6 +312,10 @@ const mapInstance = ref(null)
 const markerInstance = ref(null)
 const originalLocation = ref({ latitude: null, longitude: null })
 const skipReverseGeocode = ref(false)
+
+const publicVenueUrl = computed(() => {
+  return `${window.location.origin}/#/p/${form.value.slug || ''}`
+})
 
 const locationChanged = computed(() => {
   if (!props.isEdit || originalLocation.value.latitude === null) return false

--- a/src/layouts/PublicLayout.vue
+++ b/src/layouts/PublicLayout.vue
@@ -1,0 +1,281 @@
+<script setup>
+import { ref, computed, inject, onMounted, onUnmounted } from 'vue'
+
+const THEME_KEY = 'coreui-free-vue-admin-template-theme'
+
+const theme = ref(localStorage.getItem(THEME_KEY) || 'auto')
+const prefersDark = ref(
+  typeof window !== 'undefined'
+    ? window.matchMedia('(prefers-color-scheme: dark)').matches
+    : false
+)
+
+let mqHandler
+onMounted(() => {
+  const mq = window.matchMedia('(prefers-color-scheme: dark)')
+  mqHandler = (e) => { prefersDark.value = e.matches }
+  mq.addEventListener('change', mqHandler)
+})
+onUnmounted(() => {
+  const mq = window.matchMedia('(prefers-color-scheme: dark)')
+  if (mqHandler) mq.removeEventListener('change', mqHandler)
+})
+
+const resolvedTheme = computed(() => {
+  if (theme.value === 'auto') return prefersDark.value ? 'dark' : 'light'
+  return theme.value
+})
+
+const themeLabel = computed(() => {
+  const labels = { light: 'Tema claro', dark: 'Tema oscuro', auto: 'Automático' }
+  return labels[theme.value]
+})
+
+const cycleTheme = () => {
+  const order = ['light', 'dark', 'auto']
+  const idx = order.indexOf(theme.value)
+  theme.value = order[(idx + 1) % 3]
+  localStorage.setItem(THEME_KEY, theme.value)
+}
+
+// Venue colors injected from PublicVenueView
+const venueColors = inject('venueColors', ref({ primary: null, secondary: null }))
+
+const layoutStyle = computed(() => ({
+  '--venue-color-primary': venueColors.value?.primary || '#10b981',
+  '--venue-color-secondary': venueColors.value?.secondary || '#0ea5e9',
+}))
+</script>
+
+<template>
+  <div class="public-layout" :data-theme="resolvedTheme" :style="layoutStyle">
+    <!-- Background glow orbs -->
+    <div class="public-glow" aria-hidden="true">
+      <div class="public-orb public-orb--primary"></div>
+      <div class="public-orb public-orb--secondary"></div>
+      <div class="public-orb public-orb--bottom"></div>
+    </div>
+
+    <header class="public-header">
+      <div class="header-container">
+        <div id="public-header-left" class="header-left">
+          <!-- PublicVenueView teleports venue name here -->
+        </div>
+        <div class="header-right">
+          <button class="theme-toggle" @click="cycleTheme" :title="themeLabel">
+            <!-- Sun icon (light) -->
+            <svg v-if="theme === 'light'" viewBox="0 0 24 24" fill="none" width="16" height="16">
+              <path d="M12 3v1m0 16v1m8.66-13.66l-.71.71M4.05 19.95l-.71.71M21 12h-1M4 12H3m16.66 7.66l-.71-.71M4.05 4.05l-.71-.71M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+            <!-- Moon icon (dark) -->
+            <svg v-else-if="theme === 'dark'" viewBox="0 0 24 24" fill="none" width="16" height="16">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <!-- Auto/contrast icon -->
+            <svg v-else viewBox="0 0 24 24" fill="none" width="16" height="16">
+              <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/>
+              <path d="M12 3a9 9 0 0 1 0 18V3z" fill="currentColor"/>
+            </svg>
+          </button>
+          <!-- CabanIA brand removed from header; shown in footer and widget footers -->
+        </div>
+      </div>
+    </header>
+    <main class="public-main">
+      <router-view />
+    </main>
+    <footer class="public-footer">
+      <div class="footer-inner">
+        <span class="footer-text">Powered by</span>
+        <img src="/logo-inverted.svg" alt="CabanIA" class="footer-logo-icon" />
+        <img src="/logo-wordmark.svg" alt="CabanIA" class="footer-logo-wordmark" />
+      </div>
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+/* --- Light mode (default) --- */
+.public-layout {
+  --pl-bg: #f8fafc;
+  --pl-text: #0f172a;
+  --pl-text-secondary: #64748b;
+  --pl-text-muted: #94a3b8;
+  --pl-header-bg: rgba(255, 255, 255, 0.55);
+  --pl-header-border: rgba(255, 255, 255, 0.3);
+  --pl-footer-border: rgba(0, 0, 0, 0.06);
+  --pl-toggle-bg: rgba(255, 255, 255, 0.5);
+  --pl-toggle-border: rgba(0, 0, 0, 0.08);
+  --pl-toggle-hover: rgba(255, 255, 255, 0.8);
+  --pl-orb-opacity: 0.15;
+  --pl-orb-blur: 120px;
+
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--pl-bg);
+  color: var(--pl-text);
+  position: relative;
+  overflow-x: hidden;
+  transition: background 0.3s, color 0.3s;
+}
+
+/* --- Dark mode --- */
+.public-layout[data-theme="dark"] {
+  --pl-bg: #020617;
+  --pl-text: #f1f5f9;
+  --pl-text-secondary: #94a3b8;
+  --pl-text-muted: #64748b;
+  --pl-header-bg: rgba(2, 6, 23, 0.65);
+  --pl-header-border: rgba(255, 255, 255, 0.08);
+  --pl-footer-border: rgba(255, 255, 255, 0.08);
+  --pl-toggle-bg: rgba(255, 255, 255, 0.05);
+  --pl-toggle-border: rgba(255, 255, 255, 0.15);
+  --pl-toggle-hover: rgba(255, 255, 255, 0.1);
+  --pl-orb-opacity: 0.2;
+  --pl-orb-blur: 96px;
+}
+
+/* --- Background glow orbs --- */
+.public-glow {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.public-orb {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(var(--pl-orb-blur));
+  transition: opacity 0.5s;
+}
+
+.public-orb--primary {
+  top: -10rem;
+  left: -10%;
+  width: 520px;
+  height: 520px;
+  background: var(--venue-color-primary, #10b981);
+  opacity: var(--pl-orb-opacity);
+}
+
+.public-orb--secondary {
+  top: -10rem;
+  right: -10%;
+  width: 520px;
+  height: 520px;
+  background: var(--venue-color-secondary, #0ea5e9);
+  opacity: var(--pl-orb-opacity);
+}
+
+.public-orb--bottom {
+  bottom: -14rem;
+  left: 25%;
+  width: 620px;
+  height: 620px;
+  background: var(--venue-color-primary, #10b981);
+  opacity: calc(var(--pl-orb-opacity) * 0.6);
+}
+
+/* --- Header --- */
+.public-header {
+  background: var(--pl-header-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--pl-header-border);
+  padding: 0.6rem 0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+/* Theme toggle */
+.theme-toggle {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--pl-toggle-border);
+  background: var(--pl-toggle-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  color: var(--pl-text-secondary);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.theme-toggle:hover {
+  background: var(--pl-toggle-hover);
+  color: var(--pl-text);
+}
+
+.public-main {
+  flex: 1;
+  position: relative;
+  z-index: 1;
+}
+
+.public-footer {
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--pl-footer-border);
+  color: var(--pl-text-muted);
+  position: relative;
+  z-index: 1;
+}
+
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.footer-text {
+  font-size: 0.7rem;
+  color: var(--pl-text-muted);
+}
+
+.footer-logo-icon {
+  height: 14px;
+  width: 14px;
+  border-radius: 0.2rem;
+  object-fit: contain;
+  opacity: 0.6;
+}
+
+.footer-logo-wordmark {
+  height: 12px;
+  width: auto;
+  opacity: 0.5;
+}
+
+.public-layout[data-theme="dark"] .footer-logo-wordmark {
+  filter: brightness(0) invert(1);
+  opacity: 0.4;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -582,6 +582,17 @@ const routes = [
     ],
   },
   {
+    path: '/p/:slug',
+    name: 'PublicVenue',
+    component: () => import('@/layouts/PublicLayout.vue'),
+    children: [{
+      path: '',
+      name: 'PublicVenueDetail',
+      component: () => import('@/views/public/PublicVenueView.vue'),
+      props: true
+    }]
+  },
+  {
     path: '/pages',
     redirect: '/pages/404',
     name: 'Pages',
@@ -628,7 +639,7 @@ const router = createRouter({
 const { posthog } = usePostHog()
 
 // Public routes that don't require authentication
-const publicRoutes = ['/availability', '/pages/login', '/pages/register', '/pages/404', '/pages/500']
+const publicRoutes = ['/availability', '/p/', '/pages/login', '/pages/register', '/pages/404', '/pages/500']
 
 // Routes that don't require subscription
 const noSubscriptionRoutes = ['/no-subscription', '/profile']

--- a/src/views/public/PublicVenueView.vue
+++ b/src/views/public/PublicVenueView.vue
@@ -1,0 +1,948 @@
+<template>
+  <div v-if="loading" class="text-center py-5">
+    <div class="loading-spinner"></div>
+    <p class="mt-3 text-muted">Cargando información...</p>
+  </div>
+
+  <div v-else-if="error" class="text-center py-5">
+    <h2 class="text-muted mb-3">No encontrado</h2>
+    <p class="text-muted">La página que buscas no existe o no está disponible.</p>
+  </div>
+
+  <div v-else class="public-venue">
+    <!-- Teleport venue logo + name into page header -->
+    <Teleport to="#public-header-left">
+      <img v-if="venue.logo_url" :src="venue.logo_url" alt="" class="venue-header-logo" />
+      <svg v-else viewBox="0 0 24 24" fill="none" width="22" height="22" class="venue-header-icon">
+        <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <span class="page-header-venue">{{ venue.name }}</span>
+    </Teleport>
+    <!-- Hero Section -->
+    <section class="hero-section">
+      <div class="hero-gallery" v-if="images.length > 0"
+        @touchstart.passive="onTouchStart"
+        @touchend.passive="onTouchEnd"
+      >
+        <div class="hero-cover">
+          <transition :name="slideDirection" mode="out-in">
+            <img :src="activeImage" :alt="venue.name" class="cover-img" :key="activeImageIdx" />
+          </transition>
+          <!-- Carousel arrows -->
+          <template v-if="images.length > 1">
+            <button class="carousel-arrow carousel-arrow--left" @click="prevImage" aria-label="Anterior">
+              <svg viewBox="0 0 24 24" fill="none" width="20" height="20"><path d="M15 18l-6-6 6-6" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <button class="carousel-arrow carousel-arrow--right" @click="nextImage" aria-label="Siguiente">
+              <svg viewBox="0 0 24 24" fill="none" width="20" height="20"><path d="M9 18l6-6-6-6" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <div class="carousel-dots">
+              <button
+                v-for="(img, idx) in images"
+                :key="img.id"
+                :class="['carousel-dot', { active: activeImageIdx === idx }]"
+                @click="goToImage(idx)"
+                :aria-label="`Foto ${idx + 1}`"
+              />
+            </div>
+          </template>
+        </div>
+        <div class="hero-thumbnails" v-if="images.length > 1">
+          <button
+            v-for="(img, idx) in images"
+            :key="img.id"
+            :class="['thumb-btn', { active: activeImageIdx === idx }]"
+            @click="goToImage(idx)"
+          >
+            <img :src="img.image_url" :alt="`Foto ${idx + 1}`" />
+          </button>
+        </div>
+      </div>
+      <div class="hero-info container-narrow">
+        <div class="hero-title-row">
+          <h1 class="venue-name">{{ venue.name }}</h1>
+          <button class="hero-cta" @click="openChat">Reserva aquí</button>
+        </div>
+        <p class="venue-location" v-if="venue.city || venue.department">
+          📍 {{ [venue.city, venue.department].filter(Boolean).join(', ') }}
+        </p>
+        <div class="amenity-badges" v-if="amenities.length > 0">
+          <span v-for="a in amenities" :key="a.id" class="amenity-badge">
+            ✓ {{ a.name }}
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Info Section -->
+    <section class="info-section container-narrow" v-if="venue.venue_info || venue.delivery_info || venue.latitude">
+      <div class="info-grid">
+        <div class="info-card" v-if="venue.venue_info">
+          <h3>Sobre nosotros</h3>
+          <p class="info-text">{{ venue.venue_info }}</p>
+        </div>
+        <div class="info-card" v-if="venue.delivery_info">
+          <h3>Cómo llegar</h3>
+          <p class="info-text">{{ venue.delivery_info }}</p>
+        </div>
+      </div>
+
+      <!-- Map -->
+      <div class="map-container" v-if="venue.latitude && venue.longitude" ref="mapContainer">
+        <div id="public-venue-map" class="venue-map"></div>
+      </div>
+
+      <!-- Navigation links -->
+      <div class="nav-links" v-if="venue.waze_link || venue.google_maps_link || venue.whatsapp || venue.instagram">
+        <a v-if="venue.waze_link" :href="venue.waze_link" target="_blank" rel="noopener" class="nav-link-btn waze">
+          🗺️ Waze
+        </a>
+        <a v-if="venue.google_maps_link" :href="venue.google_maps_link" target="_blank" rel="noopener" class="nav-link-btn gmaps">
+          📍 Google Maps
+        </a>
+        <a v-if="venue.whatsapp" :href="`https://wa.me/${venue.whatsapp.replace(/[^0-9]/g, '')}`" target="_blank" rel="noopener" class="nav-link-btn whatsapp">
+          💬 WhatsApp
+        </a>
+        <a v-if="venue.instagram" :href="instagramUrl" target="_blank" rel="noopener" class="nav-link-btn instagram">
+          📸 Instagram
+        </a>
+      </div>
+    </section>
+
+    <!-- Plans Section -->
+    <section class="plans-section container-narrow" v-if="plans.length > 0">
+      <h2 class="section-title">Nuestros Planes</h2>
+      <div class="plans-grid">
+        <div v-for="plan in plans" :key="plan.id" class="plan-card">
+          <div class="plan-header">
+            <h3 class="plan-name">{{ plan.name }}</h3>
+            <span class="plan-type-badge">{{ planTypeLabel(plan.plan_type) }}</span>
+          </div>
+          <p v-if="plan.description" class="plan-description">{{ plan.description }}</p>
+          <div class="plan-details">
+            <div class="plan-prices">
+              <div v-if="plan.adult_price" class="price-item">
+                <span class="price-label">Adulto</span>
+                <span class="price-value">{{ formatCurrency(plan.adult_price) }}</span>
+              </div>
+              <div v-if="plan.child_price" class="price-item">
+                <span class="price-label">Niño</span>
+                <span class="price-value">{{ formatCurrency(plan.child_price) }}</span>
+              </div>
+            </div>
+            <div v-if="plan.check_in_time || plan.check_out_time" class="plan-schedule">
+              <span v-if="plan.check_in_time">🕐 Entrada: {{ plan.check_in_time }}</span>
+              <span v-if="plan.check_out_time">🕐 Salida: {{ plan.check_out_time }}</span>
+            </div>
+            <div v-if="plan.includes_food && plan.food_description" class="plan-food">
+              🍽️ {{ plan.food_description }}
+            </div>
+            <div v-if="plan.amenities && plan.amenities.length > 0" class="plan-amenities">
+              <span v-for="pa in plan.amenities" :key="pa.id" class="plan-amenity-tag">
+                {{ pa.name }}{{ pa.quantity > 1 ? ` x${pa.quantity}` : '' }}
+              </span>
+            </div>
+          </div>
+          <button class="plan-cta" @click="askAboutPlan(plan)">
+            Preguntar disponibilidad
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Booking Panel Widget -->
+    <BookingPanelWidget
+      v-if="venue.id"
+      ref="bookingPanel"
+      :venue-id="venue.id"
+      :plans="plans"
+      @chat-handoff="onBookingChatHandoff"
+    />
+
+    <!-- Chat Widget (floating bubble) -->
+    <ChatBubbleWidget
+      v-if="venue.id"
+      ref="chatWidget"
+      :venue="venue"
+      :venue-id="venue.id"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, provide, onMounted, onUnmounted, nextTick } from 'vue'
+import { useRoute } from 'vue-router'
+import ChatBubbleWidget from '@/components/public/ChatBubbleWidget.vue'
+import BookingPanelWidget from '@/components/public/BookingPanelWidget.vue'
+
+const route = useRoute()
+
+const loading = ref(true)
+const error = ref(false)
+const venue = ref({})
+const images = ref([])
+const amenities = ref([])
+const plans = ref([])
+const activeImageIdx = ref(0)
+
+// Provide venue brand colors to parent layout (for orbs)
+const venueColors = computed(() => ({
+  primary: venue.value.brand_color_primary || null,
+  secondary: venue.value.brand_color_secondary || null,
+}))
+provide('venueColors', venueColors)
+
+const chatWidget = ref(null)
+const bookingPanel = ref(null)
+const slideDirection = ref('slide-left')
+let touchStartX = 0
+let autoplayTimer = null
+
+const startAutoplay = () => {
+  stopAutoplay()
+  if (images.value.length > 1) {
+    autoplayTimer = setInterval(() => nextImage(), 5000)
+  }
+}
+
+const stopAutoplay = () => {
+  if (autoplayTimer) {
+    clearInterval(autoplayTimer)
+    autoplayTimer = null
+  }
+}
+
+const resetAutoplay = () => {
+  startAutoplay()
+}
+
+const prevImage = () => {
+  slideDirection.value = 'slide-right'
+  activeImageIdx.value = (activeImageIdx.value - 1 + images.value.length) % images.value.length
+  resetAutoplay()
+}
+
+const nextImage = () => {
+  slideDirection.value = 'slide-left'
+  activeImageIdx.value = (activeImageIdx.value + 1) % images.value.length
+}
+
+const goToImage = (idx) => {
+  slideDirection.value = idx > activeImageIdx.value ? 'slide-left' : 'slide-right'
+  activeImageIdx.value = idx
+  resetAutoplay()
+}
+
+const onTouchStart = (e) => {
+  touchStartX = e.changedTouches[0].clientX
+}
+
+const onTouchEnd = (e) => {
+  const diff = touchStartX - e.changedTouches[0].clientX
+  if (Math.abs(diff) > 50) {
+    if (diff > 0) nextImage()
+    else prevImage()
+  }
+  resetAutoplay()
+}
+
+onUnmounted(() => stopAutoplay())
+
+const instagramUrl = computed(() => {
+  const ig = venue.value.instagram || ''
+  if (ig.startsWith('http')) return ig
+  return `https://instagram.com/${ig.replace('@', '')}`
+})
+
+const activeImage = computed(() => {
+  if (images.value.length === 0) return ''
+  return images.value[activeImageIdx.value]?.image_url || ''
+})
+
+const loadVenue = async () => {
+  try {
+    const slug = route.params.slug
+    const response = await fetch(`/api/public/venues/${slug}`)
+    if (!response.ok) {
+      error.value = true
+      return
+    }
+    const data = await response.json()
+    venue.value = data.venue
+    images.value = data.images || []
+    amenities.value = data.amenities || []
+    plans.value = data.plans || []
+
+    // Set cover image as default
+    const coverIdx = images.value.findIndex(i => i.is_cover)
+    if (coverIdx >= 0) activeImageIdx.value = coverIdx
+    startAutoplay()
+
+  } catch (err) {
+    console.error('Error loading venue:', err)
+    error.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+const planTypeLabel = (type) => {
+  const labels = { day: 'Pasadía', pasadia: 'Pasadía', overnight: 'Hospedaje', hospedaje: 'Hospedaje', event: 'Evento', evento: 'Evento', camping: 'Camping' }
+  return labels[type] || type
+}
+
+const formatCurrency = (value) => {
+  return new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value)
+}
+
+const openChat = () => {
+  bookingPanel.value?.open()
+}
+
+const askAboutPlan = (plan) => {
+  bookingPanel.value?.open(plan)
+}
+
+const onBookingChatHandoff = (context) => {
+  chatWidget.value?.startBookingChat(context)
+}
+
+// Initialize map
+const initMap = () => {
+  if (!venue.value.latitude || !venue.value.longitude) return
+  const mapboxToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN
+  if (!mapboxToken || typeof mapboxgl === 'undefined') return
+
+  const map = new mapboxgl.Map({
+    container: 'public-venue-map',
+    style: 'mapbox://styles/mapbox/streets-v12',
+    center: [parseFloat(venue.value.longitude), parseFloat(venue.value.latitude)],
+    zoom: 14,
+    accessToken: mapboxToken,
+    interactive: true
+  })
+
+  new mapboxgl.Marker({ color: '#10b981' })
+    .setLngLat([parseFloat(venue.value.longitude), parseFloat(venue.value.latitude)])
+    .setPopup(new mapboxgl.Popup().setHTML(`<strong>${venue.value.name}</strong>`))
+    .addTo(map)
+}
+
+onMounted(async () => {
+  await loadVenue()
+  if (!error.value && venue.value.latitude) {
+    // Load Mapbox dynamically
+    if (!document.getElementById('mapbox-css')) {
+      const link = document.createElement('link')
+      link.id = 'mapbox-css'
+      link.rel = 'stylesheet'
+      link.href = 'https://api.mapbox.com/mapbox-gl-js/v3.1.0/mapbox-gl.css'
+      document.head.appendChild(link)
+
+      const script = document.createElement('script')
+      script.src = 'https://api.mapbox.com/mapbox-gl-js/v3.1.0/mapbox-gl.js'
+      script.onload = () => nextTick(initMap)
+      document.head.appendChild(script)
+    } else {
+      nextTick(initMap)
+    }
+  }
+})
+</script>
+
+<style scoped>
+.public-venue {
+  max-width: 100%;
+}
+
+:global(.venue-header-logo) {
+  height: 28px;
+  width: 28px;
+  border-radius: 0.4rem;
+  object-fit: cover;
+  margin-right: 0.5rem;
+}
+
+:global(.venue-header-icon) {
+  color: var(--venue-color-primary, #10b981);
+  margin-right: 0.4rem;
+  flex-shrink: 0;
+}
+
+:global(.page-header-venue) {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--pl-text, #0f172a);
+}
+
+.container-narrow {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+/* Hero */
+.hero-section {
+  margin-bottom: 2rem;
+}
+
+.hero-gallery {
+  position: relative;
+}
+
+.hero-cover {
+  position: relative;
+  width: 100%;
+  max-height: 450px;
+  overflow: hidden;
+  background: #e2e8f0;
+}
+
+.cover-img {
+  width: 100%;
+  height: 450px;
+  object-fit: cover;
+}
+
+/* Carousel transitions */
+.slide-left-enter-active,
+.slide-left-leave-active,
+.slide-right-enter-active,
+.slide-right-leave-active {
+  transition: opacity 0.35s ease;
+}
+
+.slide-left-enter-from,
+.slide-left-leave-to,
+.slide-right-enter-from,
+.slide-right-leave-to {
+  opacity: 0;
+}
+
+/* Carousel arrows */
+.carousel-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: #fff;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.carousel-arrow:hover {
+  background: rgba(0, 0, 0, 0.55);
+  transform: translateY(-50%) scale(1.1);
+}
+
+.carousel-arrow--left {
+  left: 0.75rem;
+}
+
+.carousel-arrow--right {
+  right: 0.75rem;
+}
+
+/* Carousel dots */
+.carousel-dots {
+  position: absolute;
+  bottom: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.4rem;
+  z-index: 10;
+}
+
+.carousel-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.45);
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.carousel-dot.active {
+  background: #fff;
+  transform: scale(1.3);
+}
+
+.hero-thumbnails {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  background: rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  justify-content: center;
+}
+
+.thumb-btn {
+  width: 60px;
+  height: 60px;
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  border-radius: 10px;
+  overflow: hidden;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.thumb-btn.active {
+  border-color: #10b981;
+  box-shadow: 0 2px 12px rgba(16, 185, 129, 0.3);
+}
+
+.thumb-btn img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hero-info {
+  padding-top: 1.5rem;
+}
+
+.hero-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.25rem;
+}
+
+.venue-name {
+  font-size: 2rem;
+  font-weight: 800;
+  color: #0f172a;
+  margin: 0;
+}
+
+.venue-location {
+  font-size: 1.05rem;
+  color: #64748b;
+  margin: 0 0 1rem;
+}
+
+.amenity-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.amenity-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem 0.75rem;
+  background: rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  border-radius: 20px;
+  font-size: 0.85rem;
+  color: #047857;
+}
+
+.amenity-icon {
+  font-size: 1rem;
+}
+
+.hero-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 800;
+  color: #fff;
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  box-shadow: 0 4px 20px rgba(16, 185, 129, 0.35);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.hero-cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 28px rgba(16, 185, 129, 0.45);
+}
+
+/* Info */
+.info-section {
+  margin-bottom: 2rem;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .info-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.info-card {
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-radius: 16px;
+  padding: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.04), 0 0 0 1px rgba(255, 255, 255, 0.2) inset;
+}
+
+.info-card h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0 0 0.5rem;
+}
+
+.info-text {
+  color: #475569;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  white-space: pre-line;
+  margin: 0;
+}
+
+.venue-map {
+  width: 100%;
+  height: 300px;
+  border-radius: 16px;
+  margin-bottom: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.nav-link-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 1rem;
+  border-radius: 10px;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: all 0.2s;
+  color: #fff;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+}
+
+.nav-link-btn.waze { background: rgba(51, 204, 255, 0.85); }
+.nav-link-btn.gmaps { background: rgba(66, 133, 244, 0.85); }
+.nav-link-btn.whatsapp { background: rgba(37, 211, 102, 0.85); }
+.nav-link-btn.instagram { background: linear-gradient(45deg, rgba(240,148,51,0.85), rgba(230,104,60,0.85), rgba(220,39,67,0.85), rgba(204,35,102,0.85), rgba(188,24,136,0.85)); }
+
+.nav-link-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  color: #fff;
+}
+
+/* Plans */
+.plans-section {
+  margin-bottom: 2rem;
+}
+
+.section-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #0f172a;
+  margin: 0 0 1.25rem;
+}
+
+.plans-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .plans-grid {
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  }
+}
+
+.plan-card {
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.04), 0 0 0 1px rgba(255, 255, 255, 0.2) inset;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.plan-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(255, 255, 255, 0.3) inset;
+}
+
+.plan-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.plan-name {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+}
+
+.plan-type-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  background: rgba(14, 165, 233, 0.1);
+  border: 1px solid rgba(14, 165, 233, 0.15);
+  color: #0369a1;
+}
+
+.plan-description {
+  color: #64748b;
+  font-size: 0.9rem;
+  margin: 0 0 0.75rem;
+}
+
+.plan-details {
+  flex: 1;
+  margin-bottom: 1rem;
+}
+
+.plan-prices {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.price-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.price-label {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+}
+
+.price-value {
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: #10b981;
+}
+
+.plan-schedule {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+}
+
+.plan-food {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+}
+
+.plan-amenities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.plan-amenity-tag {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  background: rgba(241, 245, 249, 0.6);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  border-radius: 6px;
+  color: #475569;
+}
+
+.plan-cta {
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 0.65rem 1rem;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  width: 100%;
+  box-shadow: 0 2px 12px rgba(16, 185, 129, 0.25);
+}
+
+.plan-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(16, 185, 129, 0.35);
+}
+
+/* Loading spinner */
+.loading-spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid rgba(16, 185, 129, 0.2);
+  border-top-color: #10b981;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin: 0 auto 0.5rem;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Mobile */
+@media (max-width: 640px) {
+  .venue-name {
+    font-size: 1.5rem;
+  }
+
+  .cover-img {
+    height: 280px;
+  }
+
+  .hero-thumbnails {
+    justify-content: flex-start;
+  }
+}
+
+
+</style>
+
+<!-- Dark mode overrides (unscoped — :global() with descendant selectors breaks in Vue scoped styles) -->
+<style>
+[data-theme="dark"] .hero-cover {
+  background: #1e293b;
+}
+
+[data-theme="dark"] .hero-thumbnails {
+  background: rgba(2, 6, 23, 0.65);
+}
+
+[data-theme="dark"] .thumb-btn {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] .venue-name {
+  color: #f1f5f9;
+}
+
+[data-theme="dark"] .venue-location {
+  color: #94a3b8;
+}
+
+[data-theme="dark"] .amenity-badge {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(16, 185, 129, 0.3);
+  color: #34d399;
+}
+
+[data-theme="dark"] .info-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .info-card h3 {
+  color: #f1f5f9;
+}
+
+[data-theme="dark"] .info-text {
+  color: #94a3b8;
+}
+
+[data-theme="dark"] .venue-map {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme="dark"] .section-title {
+  color: #f1f5f9;
+}
+
+[data-theme="dark"] .plan-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .plan-card:hover {
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .plan-name {
+  color: #f1f5f9;
+}
+
+[data-theme="dark"] .plan-type-badge {
+  background: rgba(14, 165, 233, 0.15);
+  border-color: rgba(14, 165, 233, 0.25);
+  color: #7dd3fc;
+}
+
+[data-theme="dark"] .plan-description {
+  color: #94a3b8;
+}
+
+[data-theme="dark"] .price-label {
+  color: #cbd5e1;
+}
+
+[data-theme="dark"] .plan-schedule {
+  color: #94a3b8;
+}
+
+[data-theme="dark"] .plan-food {
+  color: #94a3b8;
+}
+
+[data-theme="dark"] .plan-amenity-tag {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: #94a3b8;
+}
+</style>


### PR DESCRIPTION
## Summary
- Página pública accesible en `/p/:slug` con galería de fotos, info del venue, mapa interactivo, planes y amenidades
- **Booking widget**: flujo guiado de 4 pasos (plan → fecha → disponibilidad → contacto) que al finalizar hace handoff al chat con mensaje pre-armado
- **Chat bubble**: widget flotante con logo CabanIA (cabaña dentro de speech bubble), formulario de contacto, verificación por código y conversación con AI
- **Endpoint de disponibilidad** `POST /api/public/venues/:id/availability` — consulta directa sin LLM, con rate limiting (10/min por IP)
- **Dark mode** completo con overrides en bloque `<style>` no-scoped (fix para bug del compilador Vue con `:global()`)
- Footer "Powered by CabanIA" con logo + wordmark en layout, booking panel y chat

## Test plan
- [ ] Navegar a `/p/casa-baluna` y verificar que carga la página con fotos, info y planes
- [ ] Click "Reserva aquí" → booking panel se abre en paso 1 (planes)
- [ ] Seleccionar plan → avanza a paso 2 (fecha y personas)
- [ ] Verificar disponibilidad → muestra resultado en paso 3
- [ ] Continuar a paso 4 (contacto) → llenar datos → handoff al chat
- [ ] Click "Preguntar disponibilidad" en un plan → abre booking panel directo en paso 2
- [ ] Probar chat bubble independiente (consultas libres)
- [ ] Verificar dark mode: título venue, labels Adulto/Niño, planes, info cards, footer
- [ ] Verificar responsive mobile (bottom sheet en booking panel y chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)