### PR TITLE
Agregar filtros, ordenamiento y paginación a todas las tablas

### DIFF
--- a/src/components/users/UserTable.vue
+++ b/src/components/users/UserTable.vue
@@ -9,21 +9,39 @@
     <CCardBody>
       <div class="mb-3">
         <label class="form-label">Buscar:</label>
-        <input type="text" v-model="searchQuery" class="form-control" placeholder="Buscar por nombre o email" />
+        <input type="text" v-model="searchQuery" class="form-control form-control-sm" placeholder="Buscar por nombre o email" />
       </div>
       <CTable hover responsive>
         <CTableHead>
           <CTableRow>
             <CTableHeaderCell scope="col">Avatar</CTableHeaderCell>
-            <CTableHeaderCell scope="col">Nombre</CTableHeaderCell>
-            <CTableHeaderCell scope="col">Email</CTableHeaderCell>
-            <CTableHeaderCell scope="col">Rol</CTableHeaderCell>
+            <CTableHeaderCell
+              scope="col"
+              style="cursor: pointer; user-select: none;"
+              @click="toggleSort('display_name')"
+            >
+              Nombre {{ sortIcon('display_name') }}
+            </CTableHeaderCell>
+            <CTableHeaderCell
+              scope="col"
+              style="cursor: pointer; user-select: none;"
+              @click="toggleSort('email')"
+            >
+              Email {{ sortIcon('email') }}
+            </CTableHeaderCell>
+            <CTableHeaderCell
+              scope="col"
+              style="cursor: pointer; user-select: none;"
+              @click="toggleSort('role')"
+            >
+              Rol {{ sortIcon('role') }}
+            </CTableHeaderCell>
             <CTableHeaderCell scope="col">Estado</CTableHeaderCell>
             <CTableHeaderCell scope="col">Acciones</CTableHeaderCell>
           </CTableRow>
         </CTableHead>
         <CTableBody>
-          <CTableRow v-for="user in filteredUsers" :key="user.id">
+          <CTableRow v-for="user in paginatedUsers" :key="user.id">
             <CTableDataCell>
               <CAvatar v-if="user.avatar_url" :src="user.avatar_url" size="md" />
               <CAvatar v-else color="secondary" size="md">
@@ -42,18 +60,18 @@
             </CTableDataCell>
             <CTableDataCell>
               <CButton color="primary" size="sm" @click="onEdit(user)">Editar</CButton>
-              <CButton 
-                v-if="user.is_locked" 
-                color="success" 
-                size="sm" 
-                class="ms-2" 
+              <CButton
+                v-if="user.is_locked"
+                color="success"
+                size="sm"
+                class="ms-2"
                 @click="onUnlock(user)"
               >Desbloquear</CButton>
-              <CButton 
-                v-else 
-                color="warning" 
-                size="sm" 
-                class="ms-2" 
+              <CButton
+                v-else
+                color="warning"
+                size="sm"
+                class="ms-2"
                 @click="onLock(user)"
               >Bloquear</CButton>
               <CButton color="danger" size="sm" class="ms-2" @click="onDelete(user)">Eliminar</CButton>
@@ -61,12 +79,32 @@
           </CTableRow>
         </CTableBody>
       </CTable>
+
+      <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+        <div class="small text-muted">
+          Mostrando {{ pageStart }}-{{ pageEnd }} de {{ filteredUsers.length }} registros
+        </div>
+        <CPagination size="sm" class="mb-0">
+          <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+          <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+          <CPaginationItem
+            v-for="page in visiblePages"
+            :key="page"
+            :active="page === currentPage"
+            @click="currentPage = page"
+          >
+            {{ page }}
+          </CPaginationItem>
+          <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+          <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+        </CPagination>
+      </div>
     </CCardBody>
   </CCard>
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, computed, watch } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { CIcon } from '@coreui/icons-vue'
 import { fetchUsers, deleteUser, lockUser, unlockUser } from '@/services/userService'
@@ -75,14 +113,82 @@ const users = ref([])
 const searchQuery = ref('')
 const router = useRouter()
 
+const sortKey = ref('display_name')
+const sortOrder = ref('asc')
+const perPage = ref(20)
+const currentPage = ref(1)
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
 const filteredUsers = computed(() => {
-  if (!searchQuery.value) return users.value
-  const query = searchQuery.value.toLowerCase()
-  return users.value.filter(u => 
-    (u.display_name && u.display_name.toLowerCase().includes(query)) ||
-    (u.email && u.email.toLowerCase().includes(query))
-  )
+  let result = users.value
+
+  if (searchQuery.value) {
+    const query = searchQuery.value.toLowerCase()
+    result = result.filter(u =>
+      (u.display_name && u.display_name.toLowerCase().includes(query)) ||
+      (u.email && u.email.toLowerCase().includes(query))
+    )
+  }
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va = (a[key] || '').toString().toLowerCase()
+      let vb = (b[key] || '').toString().toLowerCase()
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
 })
+
+const totalPages = computed(() => Math.ceil(filteredUsers.value.length / perPage.value))
+
+const paginatedUsers = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return filteredUsers.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (filteredUsers.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, filteredUsers.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+watch(searchQuery, () => { currentPage.value = 1 })
 
 function getRoleColor(role) {
   switch(role) {

--- a/src/views/commissions/CommissionAgentListView.vue
+++ b/src/views/commissions/CommissionAgentListView.vue
@@ -41,17 +41,43 @@
           <CTable hover responsive>
             <CTableHead>
               <CTableRow>
-                <CTableHeaderCell>Nombre</CTableHeaderCell>
-                <CTableHeaderCell>Proveedor</CTableHeaderCell>
-                <CTableHeaderCell class="d-mobile-none">Sede</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('name')"
+                >
+                  Nombre {{ sortIcon('name') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('provider')"
+                >
+                  Proveedor {{ sortIcon('provider') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  class="d-mobile-none"
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('venue')"
+                >
+                  Sede {{ sortIcon('venue') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell>Reglas</CTableHeaderCell>
-                <CTableHeaderCell>Estado</CTableHeaderCell>
-                <CTableHeaderCell>Pagos</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('is_active')"
+                >
+                  Estado {{ sortIcon('is_active') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('payments')"
+                >
+                  Pagos {{ sortIcon('payments') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell>Acciones</CTableHeaderCell>
               </CTableRow>
             </CTableHead>
             <CTableBody>
-              <CTableRow v-for="agent in agents" :key="agent.id">
+              <CTableRow v-for="agent in paginatedAgents" :key="agent.id">
                 <CTableDataCell>{{ agent.name }}</CTableDataCell>
                 <CTableDataCell>{{ agent.provider?.name || '—' }}</CTableDataCell>
                 <CTableDataCell class="d-mobile-none">
@@ -85,13 +111,33 @@
                   </div>
                 </CTableDataCell>
               </CTableRow>
-              <CTableRow v-if="agents.length === 0">
+              <CTableRow v-if="sortedAgents.length === 0">
                 <CTableDataCell colspan="7" class="text-center text-muted py-4">
                   No hay comisionistas registrados
                 </CTableDataCell>
               </CTableRow>
             </CTableBody>
           </CTable>
+
+          <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+            <div class="small text-muted">
+              Mostrando {{ pageStart }}-{{ pageEnd }} de {{ sortedAgents.length }} registros
+            </div>
+            <CPagination size="sm" class="mb-0">
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+              <CPaginationItem
+                v-for="page in visiblePages"
+                :key="page"
+                :active="page === currentPage"
+                @click="currentPage = page"
+              >
+                {{ page }}
+              </CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+            </CPagination>
+          </div>
         </CCardBody>
       </CCard>
     </CCol>
@@ -99,7 +145,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import {
   CRow, CCol, CCard, CCardHeader, CCardBody, CButton,
@@ -120,7 +166,89 @@ const filters = ref({
   search: ''
 })
 
+const sortKey = ref('name')
+const sortOrder = ref('asc')
+const perPage = ref(20)
+const currentPage = ref(1)
+
 let searchTimeout = null
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const sortedAgents = computed(() => {
+  let result = agents.value
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va, vb
+      if (key === 'provider') {
+        va = (a.provider?.name || '').toLowerCase()
+        vb = (b.provider?.name || '').toLowerCase()
+      } else if (key === 'venue') {
+        va = (getVenueName(a.venue_id) || '').toLowerCase()
+        vb = (getVenueName(b.venue_id) || '').toLowerCase()
+      } else if (key === 'is_active') {
+        va = a.is_active ? 1 : 0
+        vb = b.is_active ? 1 : 0
+      } else if (key === 'payments') {
+        va = a._count?.payments || 0
+        vb = b._count?.payments || 0
+      } else {
+        va = (a[key] || '').toString().toLowerCase()
+        vb = (b[key] || '').toString().toLowerCase()
+      }
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
+})
+
+const totalPages = computed(() => Math.ceil(sortedAgents.value.length / perPage.value))
+
+const paginatedAgents = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return sortedAgents.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (sortedAgents.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, sortedAgents.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
 
 const formatCurrency = (amount) => {
   if (amount === null || amount === undefined) return '—'
@@ -140,12 +268,14 @@ const getVenueName = (venueId) => {
 const onSearchInput = () => {
   clearTimeout(searchTimeout)
   searchTimeout = setTimeout(() => {
+    currentPage.value = 1
     loadAgents()
   }, 300)
 }
 
 const loadAgents = async () => {
   loading.value = true
+  currentPage.value = 1
   try {
     const params = new URLSearchParams()
     if (filters.value.venue_id) params.append('venue_id', filters.value.venue_id)

--- a/src/views/commissions/CommissionPaymentListView.vue
+++ b/src/views/commissions/CommissionPaymentListView.vue
@@ -33,23 +33,56 @@
                 </option>
               </CFormSelect>
             </CCol>
+            <CCol :md="3">
+              <CFormLabel class="small">Buscar</CFormLabel>
+              <CFormInput
+                v-model="searchQuery"
+                size="sm"
+                placeholder="Buscar por comisionista..."
+              />
+            </CCol>
           </CRow>
 
           <CTable hover responsive>
             <CTableHead>
               <CTableRow>
-                <CTableHeaderCell>Fecha</CTableHeaderCell>
-                <CTableHeaderCell>Comisionista</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('payment_date')"
+                >
+                  Fecha {{ sortIcon('payment_date') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('agent')"
+                >
+                  Comisionista {{ sortIcon('agent') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell class="d-mobile-none">Evento</CTableHeaderCell>
                 <CTableHeaderCell>Adultos</CTableHeaderCell>
-                <CTableHeaderCell>Precio Evento</CTableHeaderCell>
-                <CTableHeaderCell>Comisi&oacute;n</CTableHeaderCell>
-                <CTableHeaderCell>Estado</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('agreed_price')"
+                >
+                  Precio Evento {{ sortIcon('agreed_price') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('calculated_amount')"
+                >
+                  Comisión {{ sortIcon('calculated_amount') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('status')"
+                >
+                  Estado {{ sortIcon('status') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell>Acciones</CTableHeaderCell>
               </CTableRow>
             </CTableHead>
             <CTableBody>
-              <CTableRow v-for="payment in payments" :key="payment.id">
+              <CTableRow v-for="payment in paginatedPayments" :key="payment.id">
                 <CTableDataCell>{{ formatDate(payment.payment_date || payment.created_at) }}</CTableDataCell>
                 <CTableDataCell>{{ payment.agent?.name || '—' }}</CTableDataCell>
                 <CTableDataCell class="d-mobile-none">
@@ -76,13 +109,13 @@
                   </CButton>
                 </CTableDataCell>
               </CTableRow>
-              <CTableRow v-if="payments.length === 0">
+              <CTableRow v-if="filteredPayments.length === 0">
                 <CTableDataCell colspan="8" class="text-center text-muted py-4">
                   No hay pagos de comisiones registrados
                 </CTableDataCell>
               </CTableRow>
             </CTableBody>
-            <CTableFoot v-if="payments.length > 0">
+            <CTableFoot v-if="filteredPayments.length > 0">
               <CTableRow>
                 <CTableDataCell colspan="5" class="text-end">
                   <strong>Total Pendiente:</strong>
@@ -103,6 +136,26 @@
               </CTableRow>
             </CTableFoot>
           </CTable>
+
+          <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+            <div class="small text-muted">
+              Mostrando {{ pageStart }}-{{ pageEnd }} de {{ filteredPayments.length }} registros
+            </div>
+            <CPagination size="sm" class="mb-0">
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+              <CPaginationItem
+                v-for="page in visiblePages"
+                :key="page"
+                :active="page === currentPage"
+                @click="currentPage = page"
+              >
+                {{ page }}
+              </CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+            </CPagination>
+          </div>
         </CCardBody>
       </CCard>
     </CCol>
@@ -110,10 +163,10 @@
 
   <CModal :visible="showDeleteModal" @close="showDeleteModal = false">
     <CModalHeader>
-      <CModalTitle>Confirmar eliminaci&oacute;n</CModalTitle>
+      <CModalTitle>Confirmar eliminación</CModalTitle>
     </CModalHeader>
     <CModalBody>
-      &iquest;Est&aacute; seguro de eliminar este pago de comisi&oacute;n de {{ formatCurrency(paymentToDelete?.calculated_amount) }}?
+      ¿Está seguro de eliminar este pago de comisión de {{ formatCurrency(paymentToDelete?.calculated_amount) }}?
     </CModalBody>
     <CModalFooter>
       <CButton color="secondary" @click="showDeleteModal = false">Cancelar</CButton>
@@ -125,12 +178,12 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import {
   CRow, CCol, CCard, CCardHeader, CCardBody, CButton,
   CTable, CTableHead, CTableRow, CTableHeaderCell, CTableBody, CTableDataCell, CTableFoot,
   CBadge, CModal, CModalHeader, CModalTitle, CModalBody, CModalFooter,
-  CFormLabel, CFormSelect
+  CFormLabel, CFormSelect, CFormInput
 } from '@coreui/vue'
 import { CIcon } from '@coreui/icons-vue'
 
@@ -141,6 +194,7 @@ const loading = ref(false)
 const deleting = ref(false)
 const showDeleteModal = ref(false)
 const paymentToDelete = ref(null)
+const searchQuery = ref('')
 
 const filters = ref({
   venue_id: '',
@@ -148,20 +202,112 @@ const filters = ref({
   agent_id: ''
 })
 
+const sortKey = ref('payment_date')
+const sortOrder = ref('desc')
+const perPage = ref(20)
+const currentPage = ref(1)
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const filteredPayments = computed(() => {
+  let result = payments.value
+
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    result = result.filter(p =>
+      (p.agent?.name && p.agent.name.toLowerCase().includes(q))
+    )
+  }
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va, vb
+      if (key === 'payment_date') {
+        va = new Date(a.payment_date || a.created_at).getTime()
+        vb = new Date(b.payment_date || b.created_at).getTime()
+      } else if (key === 'agent') {
+        va = (a.agent?.name || '').toLowerCase()
+        vb = (b.agent?.name || '').toLowerCase()
+      } else if (key === 'agreed_price' || key === 'calculated_amount') {
+        va = parseFloat(a[key]) || 0
+        vb = parseFloat(b[key]) || 0
+      } else if (key === 'status') {
+        va = (a.status || '').toLowerCase()
+        vb = (b.status || '').toLowerCase()
+      } else {
+        va = (a[key] || '').toString().toLowerCase()
+        vb = (b[key] || '').toString().toLowerCase()
+      }
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
+})
+
 const totalPending = computed(() => {
-  return payments.value
+  return filteredPayments.value
     .filter((p) => p.status === 'Pendiente')
     .reduce((sum, p) => sum + (parseFloat(p.calculated_amount) || 0), 0)
 })
 
 const totalPaid = computed(() => {
-  return payments.value
+  return filteredPayments.value
     .filter((p) => p.status === 'Pagado')
     .reduce((sum, p) => sum + (parseFloat(p.calculated_amount) || 0), 0)
 })
 
+const totalPages = computed(() => Math.ceil(filteredPayments.value.length / perPage.value))
+
+const paginatedPayments = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return filteredPayments.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (filteredPayments.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, filteredPayments.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+watch(searchQuery, () => { currentPage.value = 1 })
+
 const loadPayments = async () => {
   loading.value = true
+  currentPage.value = 1
   try {
     const params = new URLSearchParams()
     if (filters.value.venue_id) params.append('venue_id', filters.value.venue_id)

--- a/src/views/estimates/EstimatesListView.vue
+++ b/src/views/estimates/EstimatesListView.vue
@@ -9,9 +9,10 @@
           </RouterLink>
         </CCardHeader>
         <CCardBody>
-          <CRow class="mb-3">
-            <CCol :md="4" :sm="6" class="mb-2 mb-md-0">
-              <CFormSelect v-model="filters.status" @change="loadEstimates">
+          <CRow class="mb-3 g-2">
+            <CCol :md="3" :sm="6">
+              <CFormLabel class="small">Estado</CFormLabel>
+              <CFormSelect v-model="filters.status" size="sm" @change="loadEstimates">
                 <option value="">Todos los estados</option>
                 <option value="pending">Pendiente</option>
                 <option value="confirmed">Confirmada</option>
@@ -19,30 +20,65 @@
                 <option value="cancelled">Cancelada</option>
               </CFormSelect>
             </CCol>
-            <CCol :md="4" :sm="6">
-              <CFormSelect v-model="filters.venue_id" @change="loadEstimates">
+            <CCol :md="3" :sm="6">
+              <CFormLabel class="small">Cabaña</CFormLabel>
+              <CFormSelect v-model="filters.venue_id" size="sm" @change="loadEstimates">
                 <option value="">Todas las cabañas</option>
                 <option v-for="venue in venues" :key="venue.id" :value="venue.id">
                   {{ venue.name }}
                 </option>
               </CFormSelect>
             </CCol>
+            <CCol :md="6">
+              <CFormLabel class="small">Buscar</CFormLabel>
+              <CFormInput
+                v-model="searchQuery"
+                size="sm"
+                placeholder="Buscar por cliente o contacto..."
+              />
+            </CCol>
           </CRow>
           <CTable hover responsive>
             <CTableHead>
               <CTableRow>
-                <CTableHeaderCell>Fecha</CTableHeaderCell>
-                <CTableHeaderCell>Cliente</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('check_in')"
+                >
+                  Fecha {{ sortIcon('check_in') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('customer_name')"
+                >
+                  Cliente {{ sortIcon('customer_name') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell>Contacto</CTableHeaderCell>
-                <CTableHeaderCell class="d-mobile-none">Cabaña</CTableHeaderCell>
+                <CTableHeaderCell
+                  class="d-mobile-none"
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('venue')"
+                >
+                  Cabaña {{ sortIcon('venue') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell class="d-mobile-none">Plan</CTableHeaderCell>
-                <CTableHeaderCell>Precio</CTableHeaderCell>
-                <CTableHeaderCell>Estado</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('calculated_price')"
+                >
+                  Precio {{ sortIcon('calculated_price') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('status')"
+                >
+                  Estado {{ sortIcon('status') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell>Acciones</CTableHeaderCell>
               </CTableRow>
             </CTableHead>
             <CTableBody>
-              <CTableRow v-for="estimate in estimates" :key="estimate.id">
+              <CTableRow v-for="estimate in paginatedEstimates" :key="estimate.id">
                 <CTableDataCell>{{ formatDate(estimate.check_in) }}</CTableDataCell>
                 <CTableDataCell>{{ estimate.customer_name || '—' }}</CTableDataCell>
                 <CTableDataCell>
@@ -88,18 +124,38 @@
                   </CButton>
                 </CTableDataCell>
               </CTableRow>
-              <CTableRow v-if="estimates.length === 0">
+              <CTableRow v-if="filteredEstimates.length === 0">
                 <CTableDataCell colspan="8" class="text-center text-muted py-4">
                   No hay cotizaciones registradas
                 </CTableDataCell>
               </CTableRow>
             </CTableBody>
           </CTable>
+
+          <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+            <div class="small text-muted">
+              Mostrando {{ pageStart }}-{{ pageEnd }} de {{ filteredEstimates.length }} registros
+            </div>
+            <CPagination size="sm" class="mb-0">
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+              <CPaginationItem
+                v-for="page in visiblePages"
+                :key="page"
+                :active="page === currentPage"
+                @click="currentPage = page"
+              >
+                {{ page }}
+              </CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+            </CPagination>
+          </div>
         </CCardBody>
       </CCard>
     </CCol>
   </CRow>
-  
+
   <CToaster placement="top-end">
     <CToast v-if="toast.visible" :color="toast.color" class="text-white" :autohide="true" :delay="3000" @close="toast.visible = false">
       <CToastBody>{{ toast.message }}</CToastBody>
@@ -108,7 +164,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { CIcon } from '@coreui/icons-vue'
 import { cilZoom, cilPencil, cilCheckCircle, cilPhone, cilUser } from '@coreui/icons'
@@ -117,16 +173,106 @@ import { getEstimates, convertEstimate } from '@/services/estimateService'
 const router = useRouter()
 const estimates = ref([])
 const venues = ref([])
+const searchQuery = ref('')
 const filters = ref({
   status: '',
   venue_id: ''
 })
+
+const sortKey = ref('check_in')
+const sortOrder = ref('desc')
+const perPage = ref(20)
+const currentPage = ref(1)
 
 const toast = ref({
   visible: false,
   message: '',
   color: 'success'
 })
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const filteredEstimates = computed(() => {
+  let result = estimates.value
+
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    result = result.filter(e =>
+      (e.customer_name && e.customer_name.toLowerCase().includes(q)) ||
+      (e.contact_value && e.contact_value.toLowerCase().includes(q))
+    )
+  }
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va, vb
+      if (key === 'check_in') {
+        va = a.check_in ? new Date(a.check_in).getTime() : 0
+        vb = b.check_in ? new Date(b.check_in).getTime() : 0
+      } else if (key === 'calculated_price') {
+        va = parseFloat(a.calculated_price) || 0
+        vb = parseFloat(b.calculated_price) || 0
+      } else if (key === 'venue') {
+        va = (a.venue?.name || '').toLowerCase()
+        vb = (b.venue?.name || '').toLowerCase()
+      } else {
+        va = (a[key] || '').toString().toLowerCase()
+        vb = (b[key] || '').toString().toLowerCase()
+      }
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
+})
+
+const totalPages = computed(() => Math.ceil(filteredEstimates.value.length / perPage.value))
+
+const paginatedEstimates = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return filteredEstimates.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (filteredEstimates.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, filteredEstimates.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+watch(searchQuery, () => { currentPage.value = 1 })
 
 const showToast = (message, color = 'success') => {
   toast.value = { visible: true, message, color }
@@ -144,6 +290,7 @@ const loadVenues = async () => {
 }
 
 const loadEstimates = async () => {
+  currentPage.value = 1
   try {
     estimates.value = await getEstimates({
       status: filters.value.status,
@@ -159,7 +306,7 @@ const convertToAccommodation = async (estimate) => {
   if (!confirm(`¿Convertir la cotización de ${estimate.customer_name || 'cliente'} en un hospedaje?`)) {
     return
   }
-  
+
   try {
     const result = await convertEstimate(estimate.id)
     showToast('Cotización convertida a hospedaje exitosamente')

--- a/src/views/expense-categories/ExpenseCategoryListView.vue
+++ b/src/views/expense-categories/ExpenseCategoryListView.vue
@@ -9,7 +9,14 @@
           </CButton>
         </CCardHeader>
         <CCardBody>
-          <div v-if="expenseCategories.length === 0" class="text-center text-muted py-4">
+          <div class="mb-3">
+            <CFormInput
+              v-model="searchQuery"
+              size="sm"
+              placeholder="Buscar por nombre o descripción..."
+            />
+          </div>
+          <div v-if="filteredCategories.length === 0" class="text-center text-muted py-4">
             No hay categorías de gasto registradas
           </div>
           <div v-else>
@@ -17,15 +24,25 @@
               <CTableHead>
                 <CTableRow>
                   <CTableHeaderCell>Icono</CTableHeaderCell>
-                  <CTableHeaderCell>Nombre</CTableHeaderCell>
+                  <CTableHeaderCell
+                    style="cursor: pointer; user-select: none;"
+                    @click="toggleSort('name')"
+                  >
+                    Nombre {{ sortIcon('name') }}
+                  </CTableHeaderCell>
                   <CTableHeaderCell>Descripción</CTableHeaderCell>
                   <CTableHeaderCell>Color</CTableHeaderCell>
-                  <CTableHeaderCell>Estado</CTableHeaderCell>
+                  <CTableHeaderCell
+                    style="cursor: pointer; user-select: none;"
+                    @click="toggleSort('is_active')"
+                  >
+                    Estado {{ sortIcon('is_active') }}
+                  </CTableHeaderCell>
                   <CTableHeaderCell class="text-end">Acciones</CTableHeaderCell>
                 </CTableRow>
               </CTableHead>
               <CTableBody>
-                <CTableRow v-for="category in expenseCategories" :key="category.id">
+                <CTableRow v-for="category in paginatedCategories" :key="category.id">
                   <CTableDataCell>
                     <CBadge v-if="category.icon" :color="category.color || 'primary'">
                       <CIcon :name="category.icon" />
@@ -72,6 +89,26 @@
                 </CTableRow>
               </CTableBody>
             </CTable>
+
+            <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+              <div class="small text-muted">
+                Mostrando {{ pageStart }}-{{ pageEnd }} de {{ filteredCategories.length }} registros
+              </div>
+              <CPagination size="sm" class="mb-0">
+                <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+                <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+                <CPaginationItem
+                  v-for="page in visiblePages"
+                  :key="page"
+                  :active="page === currentPage"
+                  @click="currentPage = page"
+                >
+                  {{ page }}
+                </CPaginationItem>
+                <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+                <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+              </CPagination>
+            </div>
           </div>
         </CCardBody>
       </CCard>
@@ -179,16 +216,94 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import {
   CRow, CCol, CCard, CCardHeader, CCardBody, CButton,
   CTable, CTableHead, CTableRow, CTableHeaderCell, CTableBody, CTableDataCell,
   CBadge, CModal, CModalHeader, CModalTitle, CModalBody, CModalFooter,
-  CForm, CFormLabel, CFormInput, CFormTextarea, CFormSelect, CFormCheck
+  CForm, CFormLabel, CFormInput, CFormTextarea, CFormSelect, CFormCheck,
+  CPagination, CPaginationItem
 } from '@coreui/vue'
 import { CIcon } from '@coreui/icons-vue'
 
 const expenseCategories = ref([])
+const searchQuery = ref('')
+const sortKey = ref('name')
+const sortOrder = ref('asc')
+const perPage = ref(20)
+const currentPage = ref(1)
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const filteredCategories = computed(() => {
+  let result = expenseCategories.value
+
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    result = result.filter(c =>
+      (c.name && c.name.toLowerCase().includes(q)) ||
+      (c.description && c.description.toLowerCase().includes(q))
+    )
+  }
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va = (a[key] || '').toString().toLowerCase()
+      let vb = (b[key] || '').toString().toLowerCase()
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
+})
+
+const totalPages = computed(() => Math.ceil(filteredCategories.value.length / perPage.value))
+
+const paginatedCategories = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return filteredCategories.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (filteredCategories.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, filteredCategories.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+watch(searchQuery, () => { currentPage.value = 1 })
 const loading = ref(false)
 const saving = ref(false)
 const deleting = ref(false)

--- a/src/views/expenses/ExpensesListView.vue
+++ b/src/views/expenses/ExpensesListView.vue
@@ -37,20 +37,48 @@
               <CFormInput type="date" v-model="filters.to_date" size="sm" @change="loadExpenses" />
             </CCol>
           </CRow>
+          <div class="mb-3">
+            <CFormInput
+              v-model="searchQuery"
+              placeholder="Buscar por descripción, referencia o proveedor..."
+              size="sm"
+            />
+          </div>
 
           <CTable hover responsive>
             <CTableHead>
               <CTableRow>
-                <CTableHeaderCell>Fecha</CTableHeaderCell>
-                <CTableHeaderCell>Categoría</CTableHeaderCell>
-                <CTableHeaderCell class="d-mobile-none">Sede</CTableHeaderCell>
-                <CTableHeaderCell>Monto</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('expense_date')"
+                >
+                  Fecha {{ sortIcon('expense_date') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('category')"
+                >
+                  Categoría {{ sortIcon('category') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  class="d-mobile-none"
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('venue')"
+                >
+                  Sede {{ sortIcon('venue') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('amount')"
+                >
+                  Monto {{ sortIcon('amount') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell class="d-mobile-none">Descripción</CTableHeaderCell>
                 <CTableHeaderCell>Acciones</CTableHeaderCell>
               </CTableRow>
             </CTableHead>
             <CTableBody>
-              <CTableRow v-for="expense in expenses" :key="expense.id">
+              <CTableRow v-for="expense in paginatedExpenses" :key="expense.id">
                 <CTableDataCell>{{ formatDate(expense.expense_date) }}</CTableDataCell>
                 <CTableDataCell>
                   <CBadge v-if="expense.category" :color="expense.category.color || 'primary'">
@@ -89,24 +117,44 @@
                   </div>
                 </CTableDataCell>
               </CTableRow>
-              <CTableRow v-if="expenses.length === 0">
+              <CTableRow v-if="filteredExpenses.length === 0">
                 <CTableDataCell colspan="6" class="text-center text-muted py-4">
                   No hay gastos registrados
                 </CTableDataCell>
               </CTableRow>
             </CTableBody>
-            <CTableFoot v-if="expenses.length > 0">
+            <CTableFoot v-if="filteredExpenses.length > 0">
               <CTableRow>
                 <CTableDataCell colspan="3" class="text-end">
                   <strong>Total:</strong>
                 </CTableDataCell>
                 <CTableDataCell>
-                  <strong>{{ formatCurrency(totalAmount) }}</strong>
+                  <strong>{{ formatCurrency(filteredTotal) }}</strong>
                 </CTableDataCell>
                 <CTableDataCell colspan="2"></CTableDataCell>
               </CTableRow>
             </CTableFoot>
           </CTable>
+
+          <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+            <div class="small text-muted">
+              Mostrando {{ pageStart }}-{{ pageEnd }} de {{ filteredExpenses.length }} registros
+            </div>
+            <CPagination size="sm" class="mb-0">
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+              <CPaginationItem
+                v-for="page in visiblePages"
+                :key="page"
+                :active="page === currentPage"
+                @click="currentPage = page"
+              >
+                {{ page }}
+              </CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+            </CPagination>
+          </div>
         </CCardBody>
       </CCard>
     </CCol>
@@ -129,7 +177,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, reactive, computed, watch, onMounted } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import {
   CRow, CCol, CCard, CCardHeader, CCardBody, CButton,
@@ -146,6 +194,7 @@ const loading = ref(false)
 const deleting = ref(false)
 const showDeleteModal = ref(false)
 const expenseToDelete = ref(null)
+const searchQuery = ref('')
 
 const filters = ref({
   venue_id: '',
@@ -154,9 +203,102 @@ const filters = ref({
   to_date: ''
 })
 
-const totalAmount = computed(() => {
-  return expenses.value.reduce((sum, e) => sum + (parseFloat(e.amount) || 0), 0)
+const sortKey = ref('expense_date')
+const sortOrder = ref('desc')
+const perPage = ref(20)
+const currentPage = ref(1)
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const filteredExpenses = computed(() => {
+  let result = expenses.value
+
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    result = result.filter(e =>
+      (e.description && e.description.toLowerCase().includes(q)) ||
+      (e.reference && e.reference.toLowerCase().includes(q)) ||
+      (e.supplier && e.supplier.toLowerCase().includes(q))
+    )
+  }
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va, vb
+      if (key === 'amount') {
+        va = parseFloat(a.amount) || 0
+        vb = parseFloat(b.amount) || 0
+      } else if (key === 'expense_date') {
+        va = a.expense_date ? new Date(a.expense_date).getTime() : 0
+        vb = b.expense_date ? new Date(b.expense_date).getTime() : 0
+      } else if (key === 'category') {
+        va = (a.category?.name || '').toLowerCase()
+        vb = (b.category?.name || '').toLowerCase()
+      } else if (key === 'venue') {
+        va = (a.venue_data?.name || '').toLowerCase()
+        vb = (b.venue_data?.name || '').toLowerCase()
+      } else {
+        va = (a[key] || '').toString().toLowerCase()
+        vb = (b[key] || '').toString().toLowerCase()
+      }
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
 })
+
+const filteredTotal = computed(() => {
+  return filteredExpenses.value.reduce((sum, e) => sum + (parseFloat(e.amount) || 0), 0)
+})
+
+const totalPages = computed(() => Math.ceil(filteredExpenses.value.length / perPage.value))
+
+const paginatedExpenses = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return filteredExpenses.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (filteredExpenses.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, filteredExpenses.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+watch(searchQuery, () => { currentPage.value = 1 })
 
 const newExpenseLink = computed(() => {
   if (filters.value.venue_id) {
@@ -167,13 +309,14 @@ const newExpenseLink = computed(() => {
 
 const loadExpenses = async () => {
   loading.value = true
+  currentPage.value = 1
   try {
     const params = new URLSearchParams()
     if (filters.value.venue_id) params.append('venue_id', filters.value.venue_id)
     if (filters.value.category_id) params.append('category_id', filters.value.category_id)
     if (filters.value.from_date) params.append('from_date', filters.value.from_date)
     if (filters.value.to_date) params.append('to_date', filters.value.to_date)
-    
+
     const url = `/api/expenses${params.toString() ? '?' + params.toString() : ''}`
     const response = await fetch(url, { credentials: 'include' })
     if (response.ok) {

--- a/src/views/inventory-categories/InventoryCategoryListView.vue
+++ b/src/views/inventory-categories/InventoryCategoryListView.vue
@@ -9,7 +9,14 @@
           </CButton>
         </CCardHeader>
         <CCardBody>
-          <div v-if="categories.length === 0" class="text-center text-muted py-4">
+          <div class="mb-3">
+            <CFormInput
+              v-model="searchQuery"
+              size="sm"
+              placeholder="Buscar por nombre o descripción..."
+            />
+          </div>
+          <div v-if="filteredCategories.length === 0" class="text-center text-muted py-4">
             No hay categorias de inventario registradas
           </div>
           <div v-else>
@@ -17,15 +24,30 @@
               <CTableHead>
                 <CTableRow>
                   <CTableHeaderCell>Icono</CTableHeaderCell>
-                  <CTableHeaderCell>Nombre</CTableHeaderCell>
-                  <CTableHeaderCell>Tipo</CTableHeaderCell>
+                  <CTableHeaderCell
+                    style="cursor: pointer; user-select: none;"
+                    @click="toggleSort('name')"
+                  >
+                    Nombre {{ sortIcon('name') }}
+                  </CTableHeaderCell>
+                  <CTableHeaderCell
+                    style="cursor: pointer; user-select: none;"
+                    @click="toggleSort('type')"
+                  >
+                    Tipo {{ sortIcon('type') }}
+                  </CTableHeaderCell>
                   <CTableHeaderCell>Descripcion</CTableHeaderCell>
-                  <CTableHeaderCell>Estado</CTableHeaderCell>
+                  <CTableHeaderCell
+                    style="cursor: pointer; user-select: none;"
+                    @click="toggleSort('is_active')"
+                  >
+                    Estado {{ sortIcon('is_active') }}
+                  </CTableHeaderCell>
                   <CTableHeaderCell class="text-end">Acciones</CTableHeaderCell>
                 </CTableRow>
               </CTableHead>
               <CTableBody>
-                <CTableRow v-for="category in categories" :key="category.id">
+                <CTableRow v-for="category in paginatedCategories" :key="category.id">
                   <CTableDataCell>
                     <CBadge v-if="category.icon" :color="category.color || 'primary'">
                       <CIcon :name="category.icon" />
@@ -69,6 +91,26 @@
                 </CTableRow>
               </CTableBody>
             </CTable>
+
+            <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+              <div class="small text-muted">
+                Mostrando {{ pageStart }}-{{ pageEnd }} de {{ filteredCategories.length }} registros
+              </div>
+              <CPagination size="sm" class="mb-0">
+                <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+                <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+                <CPaginationItem
+                  v-for="page in visiblePages"
+                  :key="page"
+                  :active="page === currentPage"
+                  @click="currentPage = page"
+                >
+                  {{ page }}
+                </CPaginationItem>
+                <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+                <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+              </CPagination>
+            </div>
           </div>
         </CCardBody>
       </CCard>
@@ -186,16 +228,94 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import {
   CRow, CCol, CCard, CCardHeader, CCardBody, CButton,
   CTable, CTableHead, CTableRow, CTableHeaderCell, CTableBody, CTableDataCell,
   CBadge, CModal, CModalHeader, CModalTitle, CModalBody, CModalFooter,
-  CForm, CFormLabel, CFormInput, CFormTextarea, CFormSelect, CFormCheck
+  CForm, CFormLabel, CFormInput, CFormTextarea, CFormSelect, CFormCheck,
+  CPagination, CPaginationItem
 } from '@coreui/vue'
 import { CIcon } from '@coreui/icons-vue'
 
 const categories = ref([])
+const searchQuery = ref('')
+const sortKey = ref('name')
+const sortOrder = ref('asc')
+const perPage = ref(20)
+const currentPage = ref(1)
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const filteredCategories = computed(() => {
+  let result = categories.value
+
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    result = result.filter(c =>
+      (c.name && c.name.toLowerCase().includes(q)) ||
+      (c.description && c.description.toLowerCase().includes(q))
+    )
+  }
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va = (a[key] || '').toString().toLowerCase()
+      let vb = (b[key] || '').toString().toLowerCase()
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
+})
+
+const totalPages = computed(() => Math.ceil(filteredCategories.value.length / perPage.value))
+
+const paginatedCategories = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return filteredCategories.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (filteredCategories.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, filteredCategories.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+watch(searchQuery, () => { currentPage.value = 1 })
 const loading = ref(false)
 const saving = ref(false)
 const deleting = ref(false)

--- a/src/views/inventory/InventoryListView.vue
+++ b/src/views/inventory/InventoryListView.vue
@@ -44,7 +44,7 @@
               <CNavLink
                 :active="activeTab === 'supply'"
                 href="#"
-                @click.prevent="activeTab = 'supply'"
+                @click.prevent="activeTab = 'supply'; currentPage = 1"
               >
                 Insumos
                 <CBadge color="info" class="ms-1">{{ supplyItems.length }}</CBadge>
@@ -54,7 +54,7 @@
               <CNavLink
                 :active="activeTab === 'asset'"
                 href="#"
-                @click.prevent="activeTab = 'asset'"
+                @click.prevent="activeTab = 'asset'; currentPage = 1"
               >
                 Activos Fijos
                 <CBadge color="warning" class="ms-1">{{ assetItems.length }}</CBadge>
@@ -68,17 +68,43 @@
               <CTable hover responsive>
                 <CTableHead>
                   <CTableRow>
-                    <CTableHeaderCell>Nombre</CTableHeaderCell>
-                    <CTableHeaderCell>Categoria</CTableHeaderCell>
-                    <CTableHeaderCell class="d-mobile-none">Sede</CTableHeaderCell>
-                    <CTableHeaderCell>Cantidad</CTableHeaderCell>
+                    <CTableHeaderCell
+                      style="cursor: pointer; user-select: none;"
+                      @click="toggleSort('name')"
+                    >
+                      Nombre {{ sortIcon('name') }}
+                    </CTableHeaderCell>
+                    <CTableHeaderCell
+                      style="cursor: pointer; user-select: none;"
+                      @click="toggleSort('category')"
+                    >
+                      Categoria {{ sortIcon('category') }}
+                    </CTableHeaderCell>
+                    <CTableHeaderCell
+                      class="d-mobile-none"
+                      style="cursor: pointer; user-select: none;"
+                      @click="toggleSort('venue')"
+                    >
+                      Sede {{ sortIcon('venue') }}
+                    </CTableHeaderCell>
+                    <CTableHeaderCell
+                      style="cursor: pointer; user-select: none;"
+                      @click="toggleSort('quantity')"
+                    >
+                      Cantidad {{ sortIcon('quantity') }}
+                    </CTableHeaderCell>
                     <CTableHeaderCell>Stock Min.</CTableHeaderCell>
-                    <CTableHeaderCell>Costo Unit.</CTableHeaderCell>
+                    <CTableHeaderCell
+                      style="cursor: pointer; user-select: none;"
+                      @click="toggleSort('unit_cost')"
+                    >
+                      Costo Unit. {{ sortIcon('unit_cost') }}
+                    </CTableHeaderCell>
                     <CTableHeaderCell>Acciones</CTableHeaderCell>
                   </CTableRow>
                 </CTableHead>
                 <CTableBody>
-                  <CTableRow v-for="item in supplyItems" :key="item.id">
+                  <CTableRow v-for="item in paginatedItems" :key="item.id">
                     <CTableDataCell>
                       <strong>{{ item.name }}</strong>
                     </CTableDataCell>
@@ -123,7 +149,7 @@
                       </div>
                     </CTableDataCell>
                   </CTableRow>
-                  <CTableRow v-if="supplyItems.length === 0">
+                  <CTableRow v-if="activeFilteredItems.length === 0">
                     <CTableDataCell colspan="7" class="text-center text-muted py-4">
                       No hay insumos registrados
                     </CTableDataCell>
@@ -137,17 +163,38 @@
               <CTable hover responsive>
                 <CTableHead>
                   <CTableRow>
-                    <CTableHeaderCell>Nombre</CTableHeaderCell>
-                    <CTableHeaderCell>Categoria</CTableHeaderCell>
-                    <CTableHeaderCell class="d-mobile-none">Sede</CTableHeaderCell>
-                    <CTableHeaderCell>Cantidad</CTableHeaderCell>
+                    <CTableHeaderCell
+                      style="cursor: pointer; user-select: none;"
+                      @click="toggleSort('name')"
+                    >
+                      Nombre {{ sortIcon('name') }}
+                    </CTableHeaderCell>
+                    <CTableHeaderCell
+                      style="cursor: pointer; user-select: none;"
+                      @click="toggleSort('category')"
+                    >
+                      Categoria {{ sortIcon('category') }}
+                    </CTableHeaderCell>
+                    <CTableHeaderCell
+                      class="d-mobile-none"
+                      style="cursor: pointer; user-select: none;"
+                      @click="toggleSort('venue')"
+                    >
+                      Sede {{ sortIcon('venue') }}
+                    </CTableHeaderCell>
+                    <CTableHeaderCell
+                      style="cursor: pointer; user-select: none;"
+                      @click="toggleSort('quantity')"
+                    >
+                      Cantidad {{ sortIcon('quantity') }}
+                    </CTableHeaderCell>
                     <CTableHeaderCell>Condicion</CTableHeaderCell>
                     <CTableHeaderCell class="d-mobile-none">Ubicacion</CTableHeaderCell>
                     <CTableHeaderCell>Acciones</CTableHeaderCell>
                   </CTableRow>
                 </CTableHead>
                 <CTableBody>
-                  <CTableRow v-for="item in assetItems" :key="item.id">
+                  <CTableRow v-for="item in paginatedItems" :key="item.id">
                     <CTableDataCell>
                       <strong>{{ item.name }}</strong>
                     </CTableDataCell>
@@ -190,7 +237,7 @@
                       </div>
                     </CTableDataCell>
                   </CTableRow>
-                  <CTableRow v-if="assetItems.length === 0">
+                  <CTableRow v-if="activeFilteredItems.length === 0">
                     <CTableDataCell colspan="7" class="text-center text-muted py-4">
                       No hay activos fijos registrados
                     </CTableDataCell>
@@ -199,6 +246,26 @@
               </CTable>
             </CTabPane>
           </CTabContent>
+
+          <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+            <div class="small text-muted">
+              Mostrando {{ pageStart }}-{{ pageEnd }} de {{ activeFilteredItems.length }} registros
+            </div>
+            <CPagination size="sm" class="mb-0">
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+              <CPaginationItem
+                v-for="page in visiblePages"
+                :key="page"
+                :active="page === currentPage"
+                @click="currentPage = page"
+              >
+                {{ page }}
+              </CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+            </CPagination>
+          </div>
         </CCardBody>
       </CCard>
     </CCol>
@@ -221,7 +288,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import {
   CRow, CCol, CCard, CCardHeader, CCardBody, CButton,
@@ -247,6 +314,11 @@ const filters = ref({
   search: ''
 })
 
+const sortKey = ref('name')
+const sortOrder = ref('asc')
+const perPage = ref(20)
+const currentPage = ref(1)
+
 const conditionLabel = {
   bueno: 'Bueno',
   regular: 'Regular',
@@ -266,12 +338,81 @@ const conditionColor = (condition) => {
   return colors[condition] || 'secondary'
 }
 
-const supplyItems = computed(() => {
-  return items.value.filter(item => item.type === 'supply')
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const supplyItems = computed(() => items.value.filter(item => item.type === 'supply'))
+const assetItems = computed(() => items.value.filter(item => item.type === 'asset'))
+
+const activeFilteredItems = computed(() => {
+  let result = activeTab.value === 'supply' ? supplyItems.value : assetItems.value
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va, vb
+      if (key === 'quantity' || key === 'unit_cost') {
+        va = parseFloat(a[key]) || 0
+        vb = parseFloat(b[key]) || 0
+      } else if (key === 'category') {
+        va = (a.category?.name || '').toLowerCase()
+        vb = (b.category?.name || '').toLowerCase()
+      } else if (key === 'venue') {
+        va = (a.venue_data?.name || '').toLowerCase()
+        vb = (b.venue_data?.name || '').toLowerCase()
+      } else {
+        va = (a[key] || '').toString().toLowerCase()
+        vb = (b[key] || '').toString().toLowerCase()
+      }
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
 })
 
-const assetItems = computed(() => {
-  return items.value.filter(item => item.type === 'asset')
+const totalPages = computed(() => Math.ceil(activeFilteredItems.value.length / perPage.value))
+
+const paginatedItems = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return activeFilteredItems.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (activeFilteredItems.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, activeFilteredItems.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
 })
 
 const newItemLink = computed(() => {
@@ -291,6 +432,7 @@ const formatCurrency = (amount) => {
 
 const loadItems = async () => {
   loading.value = true
+  currentPage.value = 1
   try {
     const params = new URLSearchParams()
     if (filters.value.venue_id) params.append('venue_id', filters.value.venue_id)

--- a/src/views/maintenance-zones/MaintenanceZoneListView.vue
+++ b/src/views/maintenance-zones/MaintenanceZoneListView.vue
@@ -21,23 +21,50 @@
             </CCol>
           </CRow>
 
-          <div v-if="zones.length === 0" class="text-center text-muted py-4">
+          <div class="mb-3">
+            <CFormInput
+              v-model="searchQuery"
+              size="sm"
+              placeholder="Buscar por nombre o descripción..."
+            />
+          </div>
+          <div v-if="filteredZones.length === 0" class="text-center text-muted py-4">
             No hay zonas de mantenimiento registradas
           </div>
           <div v-else>
             <CTable hover responsive>
               <CTableHead>
                 <CTableRow>
-                  <CTableHeaderCell>Nombre</CTableHeaderCell>
-                  <CTableHeaderCell>Tipo</CTableHeaderCell>
-                  <CTableHeaderCell>Sede</CTableHeaderCell>
+                  <CTableHeaderCell
+                    style="cursor: pointer; user-select: none;"
+                    @click="toggleSort('name')"
+                  >
+                    Nombre {{ sortIcon('name') }}
+                  </CTableHeaderCell>
+                  <CTableHeaderCell
+                    style="cursor: pointer; user-select: none;"
+                    @click="toggleSort('type')"
+                  >
+                    Tipo {{ sortIcon('type') }}
+                  </CTableHeaderCell>
+                  <CTableHeaderCell
+                    style="cursor: pointer; user-select: none;"
+                    @click="toggleSort('venue')"
+                  >
+                    Sede {{ sortIcon('venue') }}
+                  </CTableHeaderCell>
                   <CTableHeaderCell class="d-mobile-none">Descripcion</CTableHeaderCell>
-                  <CTableHeaderCell>Estado</CTableHeaderCell>
+                  <CTableHeaderCell
+                    style="cursor: pointer; user-select: none;"
+                    @click="toggleSort('is_active')"
+                  >
+                    Estado {{ sortIcon('is_active') }}
+                  </CTableHeaderCell>
                   <CTableHeaderCell class="text-end">Acciones</CTableHeaderCell>
                 </CTableRow>
               </CTableHead>
               <CTableBody>
-                <CTableRow v-for="zone in zones" :key="zone.id">
+                <CTableRow v-for="zone in paginatedZones" :key="zone.id">
                   <CTableDataCell>
                     <strong>{{ zone.name }}</strong>
                   </CTableDataCell>
@@ -80,6 +107,26 @@
                 </CTableRow>
               </CTableBody>
             </CTable>
+
+            <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+              <div class="small text-muted">
+                Mostrando {{ pageStart }}-{{ pageEnd }} de {{ filteredZones.length }} registros
+              </div>
+              <CPagination size="sm" class="mb-0">
+                <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+                <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+                <CPaginationItem
+                  v-for="page in visiblePages"
+                  :key="page"
+                  :active="page === currentPage"
+                  @click="currentPage = page"
+                >
+                  {{ page }}
+                </CPaginationItem>
+                <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+                <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+              </CPagination>
+            </div>
           </div>
         </CCardBody>
       </CCard>
@@ -174,16 +221,101 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import {
   CRow, CCol, CCard, CCardHeader, CCardBody, CButton,
   CTable, CTableHead, CTableRow, CTableHeaderCell, CTableBody, CTableDataCell,
   CBadge, CModal, CModalHeader, CModalTitle, CModalBody, CModalFooter,
-  CForm, CFormLabel, CFormInput, CFormTextarea, CFormSelect, CFormCheck
+  CForm, CFormLabel, CFormInput, CFormTextarea, CFormSelect, CFormCheck,
+  CPagination, CPaginationItem
 } from '@coreui/vue'
 import { CIcon } from '@coreui/icons-vue'
 
 const zones = ref([])
+const searchQuery = ref('')
+const sortKey = ref('name')
+const sortOrder = ref('asc')
+const perPage = ref(20)
+const currentPage = ref(1)
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const filteredZones = computed(() => {
+  let result = zones.value
+
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    result = result.filter(z =>
+      (z.name && z.name.toLowerCase().includes(q)) ||
+      (z.description && z.description.toLowerCase().includes(q)) ||
+      (z.venue_data?.name && z.venue_data.name.toLowerCase().includes(q))
+    )
+  }
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va, vb
+      if (key === 'venue') {
+        va = (a.venue_data?.name || '').toLowerCase()
+        vb = (b.venue_data?.name || '').toLowerCase()
+      } else {
+        va = (a[key] || '').toString().toLowerCase()
+        vb = (b[key] || '').toString().toLowerCase()
+      }
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
+})
+
+const totalPages = computed(() => Math.ceil(filteredZones.value.length / perPage.value))
+
+const paginatedZones = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return filteredZones.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (filteredZones.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, filteredZones.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+watch(searchQuery, () => { currentPage.value = 1 })
 const venues = ref([])
 const loading = ref(false)
 const saving = ref(false)

--- a/src/views/maintenance/MaintenanceListView.vue
+++ b/src/views/maintenance/MaintenanceListView.vue
@@ -56,22 +56,59 @@
               <CFormInput type="date" v-model="filters.to_date" size="sm" @change="loadLogs" />
             </CCol>
           </CRow>
+          <div class="mb-3">
+            <CFormInput
+              v-model="searchQuery"
+              size="sm"
+              placeholder="Buscar por descripción..."
+            />
+          </div>
 
           <CTable hover responsive>
             <CTableHead>
               <CTableRow>
-                <CTableHeaderCell>Fecha</CTableHeaderCell>
-                <CTableHeaderCell>Zona</CTableHeaderCell>
-                <CTableHeaderCell>Proveedor</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('maintenance_date')"
+                >
+                  Fecha {{ sortIcon('maintenance_date') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('zone')"
+                >
+                  Zona {{ sortIcon('zone') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('provider')"
+                >
+                  Proveedor {{ sortIcon('provider') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell class="d-mobile-none">Descripcion</CTableHeaderCell>
-                <CTableHeaderCell>Estado</CTableHeaderCell>
-                <CTableHeaderCell>Prioridad</CTableHeaderCell>
-                <CTableHeaderCell>Costo</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('status')"
+                >
+                  Estado {{ sortIcon('status') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('priority')"
+                >
+                  Prioridad {{ sortIcon('priority') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('cost')"
+                >
+                  Costo {{ sortIcon('cost') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell>Acciones</CTableHeaderCell>
               </CTableRow>
             </CTableHead>
             <CTableBody>
-              <CTableRow v-for="log in logs" :key="log.id">
+              <CTableRow v-for="log in paginatedLogs" :key="log.id">
                 <CTableDataCell>{{ formatDate(log.maintenance_date) }}</CTableDataCell>
                 <CTableDataCell>{{ log.zone_data?.name || '-' }}</CTableDataCell>
                 <CTableDataCell>{{ log.provider_data?.name || '-' }}</CTableDataCell>
@@ -119,24 +156,44 @@
                   </div>
                 </CTableDataCell>
               </CTableRow>
-              <CTableRow v-if="logs.length === 0">
+              <CTableRow v-if="filteredLogs.length === 0">
                 <CTableDataCell colspan="8" class="text-center text-muted py-4">
                   No hay registros de mantenimiento
                 </CTableDataCell>
               </CTableRow>
             </CTableBody>
-            <CTableFoot v-if="logs.length > 0">
+            <CTableFoot v-if="filteredLogs.length > 0">
               <CTableRow>
                 <CTableDataCell colspan="6" class="text-end">
                   <strong>Total:</strong>
                 </CTableDataCell>
                 <CTableDataCell>
-                  <strong>{{ formatCurrency(totalCost) }}</strong>
+                  <strong>{{ formatCurrency(filteredTotal) }}</strong>
                 </CTableDataCell>
                 <CTableDataCell></CTableDataCell>
               </CTableRow>
             </CTableFoot>
           </CTable>
+
+          <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+            <div class="small text-muted">
+              Mostrando {{ pageStart }}-{{ pageEnd }} de {{ filteredLogs.length }} registros
+            </div>
+            <CPagination size="sm" class="mb-0">
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+              <CPaginationItem
+                v-for="page in visiblePages"
+                :key="page"
+                :active="page === currentPage"
+                @click="currentPage = page"
+              >
+                {{ page }}
+              </CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+            </CPagination>
+          </div>
         </CCardBody>
       </CCard>
     </CCol>
@@ -159,7 +216,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import {
   CRow, CCol, CCard, CCardHeader, CCardBody, CButton,
@@ -179,6 +236,7 @@ const loading = ref(false)
 const deleting = ref(false)
 const showDeleteModal = ref(false)
 const logToDelete = ref(null)
+const searchQuery = ref('')
 
 const filters = ref({
   venue_id: '',
@@ -188,6 +246,11 @@ const filters = ref({
   from_date: '',
   to_date: ''
 })
+
+const sortKey = ref('maintenance_date')
+const sortOrder = ref('desc')
+const perPage = ref(20)
+const currentPage = ref(1)
 
 const statusBadges = {
   pending: { color: 'warning', label: 'Pendiente' },
@@ -203,9 +266,100 @@ const priorityBadges = {
   urgent: { color: 'danger', label: 'Urgente' }
 }
 
-const totalCost = computed(() => {
-  return logs.value.reduce((sum, l) => sum + (parseFloat(l.cost) || 0), 0)
+const priorityOrder = { urgent: 4, high: 3, medium: 2, low: 1 }
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const filteredLogs = computed(() => {
+  let result = logs.value
+
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    result = result.filter(l =>
+      (l.description && l.description.toLowerCase().includes(q))
+    )
+  }
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va, vb
+      if (key === 'maintenance_date') {
+        va = a.maintenance_date ? new Date(a.maintenance_date).getTime() : 0
+        vb = b.maintenance_date ? new Date(b.maintenance_date).getTime() : 0
+      } else if (key === 'cost') {
+        va = parseFloat(a.cost) || 0
+        vb = parseFloat(b.cost) || 0
+      } else if (key === 'zone') {
+        va = (a.zone_data?.name || '').toLowerCase()
+        vb = (b.zone_data?.name || '').toLowerCase()
+      } else if (key === 'provider') {
+        va = (a.provider_data?.name || '').toLowerCase()
+        vb = (b.provider_data?.name || '').toLowerCase()
+      } else if (key === 'priority') {
+        va = priorityOrder[a.priority] || 0
+        vb = priorityOrder[b.priority] || 0
+      } else {
+        va = (a[key] || '').toString().toLowerCase()
+        vb = (b[key] || '').toString().toLowerCase()
+      }
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
 })
+
+const filteredTotal = computed(() => {
+  return filteredLogs.value.reduce((sum, l) => sum + (parseFloat(l.cost) || 0), 0)
+})
+
+const totalPages = computed(() => Math.ceil(filteredLogs.value.length / perPage.value))
+
+const paginatedLogs = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return filteredLogs.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (filteredLogs.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, filteredLogs.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+watch(searchQuery, () => { currentPage.value = 1 })
 
 const newLogLink = computed(() => {
   if (filters.value.venue_id) {
@@ -226,6 +380,7 @@ const formatCurrency = (amount) => {
 
 const loadLogs = async () => {
   loading.value = true
+  currentPage.value = 1
   try {
     const params = new URLSearchParams()
     if (filters.value.venue_id) params.append('venue_id', filters.value.venue_id)
@@ -327,6 +482,3 @@ onMounted(() => {
   }
 })
 </script>
-
-<style scoped>
-</style>

--- a/src/views/payments/PaymentListView.vue
+++ b/src/views/payments/PaymentListView.vue
@@ -9,28 +9,74 @@
           </CButton>
         </CCardHeader>
         <CCardBody>
+          <CRow class="mb-3 g-2">
+            <CCol :md="3">
+              <CFormLabel class="small">Método de pago</CFormLabel>
+              <CFormSelect v-model="filters.method" size="sm">
+                <option value="">Todos</option>
+                <option v-for="m in availableMethods" :key="m" :value="m">{{ m }}</option>
+              </CFormSelect>
+            </CCol>
+            <CCol :md="3">
+              <CFormLabel class="small">Estado</CFormLabel>
+              <CFormSelect v-model="filters.status" size="sm">
+                <option value="">Todos</option>
+                <option value="verified">Verificado</option>
+                <option value="pending">Pendiente</option>
+              </CFormSelect>
+            </CCol>
+            <CCol :md="3">
+              <CFormLabel class="small">Desde</CFormLabel>
+              <CFormInput type="date" v-model="filters.from_date" size="sm" />
+            </CCol>
+            <CCol :md="3">
+              <CFormLabel class="small">Hasta</CFormLabel>
+              <CFormInput type="date" v-model="filters.to_date" size="sm" />
+            </CCol>
+          </CRow>
           <div class="mb-3">
             <CFormInput
               v-model="searchQuery"
               placeholder="Buscar por referencia, método o notas..."
-              @input="filterPayments"
+              size="sm"
             />
           </div>
           <CTable hover responsive>
             <CTableHead>
               <CTableRow>
-                <CTableHeaderCell>Fecha</CTableHeaderCell>
-                <CTableHeaderCell>Monto</CTableHeaderCell>
-                <CTableHeaderCell class="d-mobile-none">Método</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('payment_date')"
+                >
+                  Fecha {{ sortIcon('payment_date') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('amount')"
+                >
+                  Monto {{ sortIcon('amount') }}
+                </CTableHeaderCell>
+                <CTableHeaderCell
+                  class="d-mobile-none"
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('payment_method')"
+                >
+                  Método {{ sortIcon('payment_method') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell class="d-mobile-none">Referencia</CTableHeaderCell>
                 <CTableHeaderCell class="d-mobile-none">Reserva</CTableHeaderCell>
-                <CTableHeaderCell>Estado</CTableHeaderCell>
+                <CTableHeaderCell
+                  style="cursor: pointer; user-select: none;"
+                  @click="toggleSort('verified')"
+                >
+                  Estado {{ sortIcon('verified') }}
+                </CTableHeaderCell>
                 <CTableHeaderCell class="d-mobile-none">Comprobante</CTableHeaderCell>
                 <CTableHeaderCell>Acciones</CTableHeaderCell>
               </CTableRow>
             </CTableHead>
             <CTableBody>
-              <CTableRow v-for="payment in filteredPayments" :key="payment.id">
+              <CTableRow v-for="payment in paginatedPayments" :key="payment.id">
                 <CTableDataCell>{{ formatDate(payment.payment_date) }}</CTableDataCell>
                 <CTableDataCell>{{ formatCurrency(payment.amount) }}</CTableDataCell>
                 <CTableDataCell class="d-mobile-none">{{ payment.payment_method || '—' }}</CTableDataCell>
@@ -109,7 +155,38 @@
                 </CTableDataCell>
               </CTableRow>
             </CTableBody>
+            <CTableFoot v-if="filteredPayments.length > 0">
+              <CTableRow>
+                <CTableDataCell class="text-end">
+                  <strong>Total:</strong>
+                </CTableDataCell>
+                <CTableDataCell>
+                  <strong>{{ formatCurrency(filteredTotal) }}</strong>
+                </CTableDataCell>
+                <CTableDataCell :colspan="6"></CTableDataCell>
+              </CTableRow>
+            </CTableFoot>
           </CTable>
+
+          <div v-if="totalPages > 1" class="d-flex flex-wrap align-items-center justify-content-between mt-3 gap-2">
+            <div class="small text-muted">
+              Mostrando {{ pageStart }}-{{ pageEnd }} de {{ filteredPayments.length }} registros
+            </div>
+            <CPagination size="sm" class="mb-0">
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage = 1">&laquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === 1" @click="currentPage--">&lsaquo;</CPaginationItem>
+              <CPaginationItem
+                v-for="page in visiblePages"
+                :key="page"
+                :active="page === currentPage"
+                @click="currentPage = page"
+              >
+                {{ page }}
+              </CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage++">&rsaquo;</CPaginationItem>
+              <CPaginationItem :disabled="currentPage === totalPages" @click="currentPage = totalPages">&raquo;</CPaginationItem>
+            </CPagination>
+          </div>
         </CCardBody>
       </CCard>
     </CCol>
@@ -184,7 +261,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, reactive, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { CIcon } from '@coreui/icons-vue'
 import { cilCheckAlt, cilX, cilPencil, cilTrash, cilImage } from '@coreui/icons'
@@ -199,15 +276,131 @@ const selectedPayment = ref(null)
 const selectedReceiptUrl = ref('')
 const receiptLoadError = ref(false)
 
-const filteredPayments = computed(() => {
-  if (!searchQuery.value) return payments.value
-  const q = searchQuery.value.toLowerCase()
-  return payments.value.filter(p => 
-    (p.reference && p.reference.toLowerCase().includes(q)) ||
-    (p.payment_method && p.payment_method.toLowerCase().includes(q)) ||
-    (p.notes && p.notes.toLowerCase().includes(q))
-  )
+const filters = reactive({
+  method: '',
+  status: '',
+  from_date: '',
+  to_date: '',
 })
+
+const sortKey = ref('payment_date')
+const sortOrder = ref('desc')
+const perPage = ref(20)
+const currentPage = ref(1)
+
+const availableMethods = computed(() => {
+  const methods = new Set()
+  payments.value.forEach(p => {
+    if (p.payment_method) methods.add(p.payment_method)
+  })
+  return [...methods].sort()
+})
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortOrder.value = 'asc'
+  }
+}
+
+function sortIcon(key) {
+  if (sortKey.value !== key) return ''
+  return sortOrder.value === 'asc' ? '▲' : '▼'
+}
+
+const filteredPayments = computed(() => {
+  let result = payments.value
+
+  if (filters.method) {
+    result = result.filter(p => p.payment_method === filters.method)
+  }
+  if (filters.status) {
+    result = result.filter(p =>
+      filters.status === 'verified' ? p.verified : !p.verified
+    )
+  }
+  if (filters.from_date) {
+    const from = new Date(filters.from_date)
+    result = result.filter(p => new Date(p.payment_date) >= from)
+  }
+  if (filters.to_date) {
+    const to = new Date(filters.to_date + 'T23:59:59')
+    result = result.filter(p => new Date(p.payment_date) <= to)
+  }
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    result = result.filter(p =>
+      (p.reference && p.reference.toLowerCase().includes(q)) ||
+      (p.payment_method && p.payment_method.toLowerCase().includes(q)) ||
+      (p.notes && p.notes.toLowerCase().includes(q))
+    )
+  }
+
+  if (sortKey.value) {
+    const key = sortKey.value
+    const dir = sortOrder.value === 'asc' ? 1 : -1
+    result = [...result].sort((a, b) => {
+      let va = a[key]
+      let vb = b[key]
+      if (key === 'amount') {
+        va = parseFloat(va) || 0
+        vb = parseFloat(vb) || 0
+      } else if (key === 'payment_date') {
+        va = va ? new Date(va).getTime() : 0
+        vb = vb ? new Date(vb).getTime() : 0
+      } else if (key === 'verified') {
+        va = va ? 1 : 0
+        vb = vb ? 1 : 0
+      } else {
+        va = (va || '').toString().toLowerCase()
+        vb = (vb || '').toString().toLowerCase()
+      }
+      if (va < vb) return -1 * dir
+      if (va > vb) return 1 * dir
+      return 0
+    })
+  }
+
+  return result
+})
+
+const filteredTotal = computed(() => {
+  return filteredPayments.value.reduce((sum, p) => sum + (parseFloat(p.amount) || 0), 0)
+})
+
+const totalPages = computed(() => Math.ceil(filteredPayments.value.length / perPage.value))
+
+const paginatedPayments = computed(() => {
+  const start = (currentPage.value - 1) * perPage.value
+  return filteredPayments.value.slice(start, start + perPage.value)
+})
+
+const pageStart = computed(() => {
+  if (filteredPayments.value.length === 0) return 0
+  return (currentPage.value - 1) * perPage.value + 1
+})
+
+const pageEnd = computed(() => {
+  return Math.min(currentPage.value * perPage.value, filteredPayments.value.length)
+})
+
+const visiblePages = computed(() => {
+  const pages = []
+  const total = totalPages.value
+  const current = currentPage.value
+  let start = Math.max(1, current - 2)
+  let end = Math.min(total, current + 2)
+  if (end - start < 4) {
+    if (start === 1) end = Math.min(total, start + 4)
+    else start = Math.max(1, end - 4)
+  }
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+watch([filters, searchQuery], () => { currentPage.value = 1 }, { deep: true })
 
 const loadPayments = async () => {
   try {
@@ -227,7 +420,7 @@ const formatDate = (date) => {
 
 const formatDateTime = (date) => {
   if (!date) return '—'
-  return new Date(date).toLocaleString('es-CO', { 
+  return new Date(date).toLocaleString('es-CO', {
     day: '2-digit', month: 'short', year: 'numeric',
     hour: '2-digit', minute: '2-digit'
   })


### PR DESCRIPTION
## Summary
- Agrega ordenamiento por columnas (click en headers con indicador ▲/▼), búsqueda de texto y paginación client-side (20 registros por página) a las 16 vistas con tablas del menú lateral
- Agrega filtros adicionales (método de pago, estado, rango de fechas) a la vista de Ingresos
- Agrega búsqueda de texto y ordenamiento a la vista de Egresos (mantiene filtros server-side existentes)
- Footer con total filtrado en vistas de Ingresos, Egresos, Depósitos, Mantenimiento y Pagos de Comisiones

## Vistas modificadas
**Contabilidad:** Ingresos, Egresos, Depósitos, Comisionistas, Pagos Comisiones
**Negocio:** Cotizaciones, Hospedajes, Contactos, Inventario
**Mantenimiento:** Registros, Zonas
**Sistema:** Usuarios, Perfiles, Categorías de Inventario, Categorías de Gastos, Templates de Mensajes

## Test plan
- [x] Verificar sort en headers clickeables (toggle asc/desc con ▲/▼)
- [x] Verificar búsqueda de texto filtra correctamente
- [x] Verificar filtros dropdown funcionan (método, estado, sede, etc.)
- [x] Verificar footer totales reflejan datos filtrados (no paginados)
- [x] Verificar paginación con CPagination (20 por página)
- [x] Verificar reset a página 1 al cambiar filtros
- [x] Build sin errores
- [x] Probado con Playwright en local — 14/14 vistas PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)