### PR TITLE
feat: Reorganizar vistas de detalle con tabs y botones en header

### DIFF
--- a/src/views/accommodations/AccommodationDetailView.vue
+++ b/src/views/accommodations/AccommodationDetailView.vue
@@ -17,137 +17,170 @@
           </div>
         </CCardHeader>
         <CCardBody v-if="accommodation">
-          <CRow>
-            <CCol :md="6">
-              <h6 class="text-muted">Cliente</h6>
-              <p class="fs-5">{{ accommodation.customer_data?.fullname || accommodation.customer_data?.user_data?.email || '—' }}</p>
-            </CCol>
-            <CCol :md="6">
-              <h6 class="text-muted">Cabaña</h6>
-              <p class="fs-5">
-                <router-link 
-                  v-if="accommodation.venue_data?.id" 
-                  :to="`/business/venues/${accommodation.venue_data.id}`"
-                  class="text-decoration-none"
-                >
-                  {{ accommodation.venue_data?.name || '—' }}
-                </router-link>
-                <span v-else>{{ accommodation.venue_data?.name || '—' }}</span>
-              </p>
-            </CCol>
-          </CRow>
-          <CRow class="mt-3">
-            <CCol :md="6">
-              <h6 class="text-muted">Organización</h6>
-              <p>{{ accommodation.venue_data?.organization_data?.name || '—' }}</p>
-            </CCol>
-            <CCol :md="6">
-              <h6 class="text-muted">Fecha</h6>
-              <p>{{ formatDate(accommodation.date) }}</p>
-            </CCol>
-          </CRow>
-          <CRow class="mt-3">
-            <CCol :md="6">
-              <h6 class="text-muted">Check In</h6>
-              <p>{{ formatTime(accommodation.time) }}</p>
-            </CCol>
-            <CCol :md="6">
-              <h6 class="text-muted">Duración</h6>
-              <p>{{ formatDuration(accommodation.duration) }}</p>
-            </CCol>
-          </CRow>
-          <CRow class="mt-3">
-            <CCol :md="6">
-              <h6 class="text-muted">Check Out</h6>
-              <p>{{ calcCheckout(accommodation.time, accommodation.duration, accommodation.date) }}</p>
-            </CCol>
-            <CCol :md="6">
-              <h6 class="text-muted">Creado</h6>
-              <p>{{ new Date(accommodation.created_at).toLocaleString('es-CO') }}</p>
-            </CCol>
-          </CRow>
-          <CRow class="mt-3">
-            <CCol :md="4">
-              <h6 class="text-muted">Total Asistentes</h6>
-              <p class="fs-4 fw-bold">{{ (accommodation.adults || 0) + (accommodation.children || 0) }}</p>
-            </CCol>
-            <CCol :md="4">
-              <h6 class="text-muted">Adultos</h6>
-              <p class="fs-5">{{ accommodation.adults || 0 }}</p>
-            </CCol>
-            <CCol :md="4">
-              <h6 class="text-muted">Niños</h6>
-              <p class="fs-5">{{ accommodation.children || 0 }}</p>
-            </CCol>
-          </CRow>
-          <hr />
-          <CRow class="mt-3">
-            <CCol :xs="12">
-              <h5 class="mb-3">Resumen Financiero</h5>
-              <div class="row g-3">
-                <div class="col-md-4">
-                  <div class="p-3 border rounded text-center">
-                    <h6 class="text-muted mb-2">Valor Alquilado</h6>
-                    <p class="fs-4 fw-bold text-primary mb-0">{{ formatCurrency(accommodation.agreed_price || accommodation.calculated_price || 0) }}</p>
-                    <small v-if="hasDiscount" class="text-success">
-                      <s class="text-muted">${{ formatNumber(accommodation.calculated_price) }}</s>
-                      (-{{ discountPercent }}%)
-                    </small>
+          <CNav variant="tabs" class="mb-3">
+            <CNavItem>
+              <CNavLink href="javascript:void(0)" :active="activeTab === 0" @click="activeTab = 0">
+                Resumen
+              </CNavLink>
+            </CNavItem>
+            <CNavItem>
+              <CNavLink href="javascript:void(0)" :active="activeTab === 1" @click="activeTab = 1">
+                Pagos
+              </CNavLink>
+            </CNavItem>
+            <CNavItem>
+              <CNavLink href="javascript:void(0)" :active="activeTab === 2" @click="activeTab = 2">
+                Depósito
+              </CNavLink>
+            </CNavItem>
+            <CNavItem>
+              <CNavLink href="javascript:void(0)" :active="activeTab === 3" @click="activeTab = 3">
+                Comisiones y Gastos
+              </CNavLink>
+            </CNavItem>
+            <CNavItem>
+              <CNavLink href="javascript:void(0)" :active="activeTab === 4" @click="activeTab = 4">
+                Mensajes
+              </CNavLink>
+            </CNavItem>
+          </CNav>
+
+          <CTabContent>
+            <!-- Tab Resumen -->
+            <CTabPane :visible="activeTab === 0">
+              <CRow>
+                <CCol :md="6">
+                  <h6 class="text-muted">Cliente</h6>
+                  <p class="fs-5">{{ accommodation.customer_data?.fullname || accommodation.customer_data?.user_data?.email || '—' }}</p>
+                </CCol>
+                <CCol :md="6">
+                  <h6 class="text-muted">Cabaña</h6>
+                  <p class="fs-5">
+                    <router-link
+                      v-if="accommodation.venue_data?.id"
+                      :to="`/business/venues/${accommodation.venue_data.id}`"
+                      class="text-decoration-none"
+                    >
+                      {{ accommodation.venue_data?.name || '—' }}
+                    </router-link>
+                    <span v-else>{{ accommodation.venue_data?.name || '—' }}</span>
+                  </p>
+                </CCol>
+              </CRow>
+              <CRow class="mt-3">
+                <CCol :md="6">
+                  <h6 class="text-muted">Organización</h6>
+                  <p>{{ accommodation.venue_data?.organization_data?.name || '—' }}</p>
+                </CCol>
+                <CCol :md="6">
+                  <h6 class="text-muted">Fecha</h6>
+                  <p>{{ formatDate(accommodation.date) }}</p>
+                </CCol>
+              </CRow>
+              <CRow class="mt-3">
+                <CCol :md="6">
+                  <h6 class="text-muted">Check In</h6>
+                  <p>{{ formatTime(accommodation.time) }}</p>
+                </CCol>
+                <CCol :md="6">
+                  <h6 class="text-muted">Duración</h6>
+                  <p>{{ formatDuration(accommodation.duration) }}</p>
+                </CCol>
+              </CRow>
+              <CRow class="mt-3">
+                <CCol :md="6">
+                  <h6 class="text-muted">Check Out</h6>
+                  <p>{{ calcCheckout(accommodation.time, accommodation.duration, accommodation.date) }}</p>
+                </CCol>
+                <CCol :md="6">
+                  <h6 class="text-muted">Creado</h6>
+                  <p>{{ new Date(accommodation.created_at).toLocaleString('es-CO') }}</p>
+                </CCol>
+              </CRow>
+              <CRow class="mt-3">
+                <CCol :md="4">
+                  <h6 class="text-muted">Total Asistentes</h6>
+                  <p class="fs-4 fw-bold">{{ (accommodation.adults || 0) + (accommodation.children || 0) }}</p>
+                </CCol>
+                <CCol :md="4">
+                  <h6 class="text-muted">Adultos</h6>
+                  <p class="fs-5">{{ accommodation.adults || 0 }}</p>
+                </CCol>
+                <CCol :md="4">
+                  <h6 class="text-muted">Niños</h6>
+                  <p class="fs-5">{{ accommodation.children || 0 }}</p>
+                </CCol>
+              </CRow>
+              <hr />
+              <CRow class="mt-3">
+                <CCol :xs="12">
+                  <h5 class="mb-3">Resumen Financiero</h5>
+                  <div class="row g-3">
+                    <div class="col-md-4">
+                      <div class="p-3 border rounded text-center">
+                        <h6 class="text-muted mb-2">Valor Alquilado</h6>
+                        <p class="fs-4 fw-bold text-primary mb-0">{{ formatCurrency(accommodation.agreed_price || accommodation.calculated_price || 0) }}</p>
+                        <small v-if="hasDiscount" class="text-success">
+                          <s class="text-muted">${{ formatNumber(accommodation.calculated_price) }}</s>
+                          (-{{ discountPercent }}%)
+                        </small>
+                      </div>
+                    </div>
+                    <div class="col-md-4">
+                      <div class="p-3 border rounded text-center">
+                        <h6 class="text-muted mb-2">Total Abonado</h6>
+                        <p class="fs-4 fw-bold text-success mb-0">{{ formatCurrency(totalPaid) }}</p>
+                      </div>
+                    </div>
+                    <div class="col-md-4">
+                      <div class="p-3 border rounded text-center" :class="{ 'border-danger': pendingBalance > 0, 'border-success': pendingBalance <= 0 }">
+                        <h6 class="text-muted mb-2">Saldo Pendiente</h6>
+                        <p class="fs-4 fw-bold mb-0" :class="{ 'text-danger': pendingBalance > 0, 'text-success': pendingBalance <= 0 }">
+                          {{ formatCurrency(pendingBalance) }}
+                        </p>
+                        <small v-if="pendingBalance <= 0" class="text-success">Pagado</small>
+                      </div>
+                    </div>
                   </div>
-                </div>
-                <div class="col-md-4">
-                  <div class="p-3 border rounded text-center">
-                    <h6 class="text-muted mb-2">Total Abonado</h6>
-                    <p class="fs-4 fw-bold text-success mb-0">{{ formatCurrency(totalPaid) }}</p>
+                  <div class="row g-3 mt-2">
+                    <div class="col-md-6">
+                      <div class="p-3 border rounded text-center">
+                        <h6 class="text-muted mb-2">Total Egresos</h6>
+                        <p class="fs-4 fw-bold text-warning mb-0">{{ formatCurrency(totalExpenses) }}</p>
+                      </div>
+                    </div>
+                    <div class="col-md-6">
+                      <div class="p-3 border rounded text-center" :class="{ 'border-success': profit >= 0, 'border-danger': profit < 0 }">
+                        <h6 class="text-muted mb-2">Ganancia</h6>
+                        <p class="fs-4 fw-bold mb-0" :class="{ 'text-success': profit >= 0, 'text-danger': profit < 0 }">
+                          {{ formatCurrency(profit) }}
+                        </p>
+                      </div>
+                    </div>
                   </div>
-                </div>
-                <div class="col-md-4">
-                  <div class="p-3 border rounded text-center" :class="{ 'border-danger': pendingBalance > 0, 'border-success': pendingBalance <= 0 }">
-                    <h6 class="text-muted mb-2">Saldo Pendiente</h6>
-                    <p class="fs-4 fw-bold mb-0" :class="{ 'text-danger': pendingBalance > 0, 'text-success': pendingBalance <= 0 }">
-                      {{ formatCurrency(pendingBalance) }}
-                    </p>
-                    <small v-if="pendingBalance <= 0" class="text-success">Pagado</small>
-                  </div>
-                </div>
-              </div>
-              <div class="row g-3 mt-2">
-                <div class="col-md-6">
-                  <div class="p-3 border rounded text-center">
-                    <h6 class="text-muted mb-2">Total Egresos</h6>
-                    <p class="fs-4 fw-bold text-warning mb-0">{{ formatCurrency(totalExpenses) }}</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="p-3 border rounded text-center" :class="{ 'border-success': profit >= 0, 'border-danger': profit < 0 }">
-                    <h6 class="text-muted mb-2">Ganancia</h6>
-                    <p class="fs-4 fw-bold mb-0" :class="{ 'text-success': profit >= 0, 'text-danger': profit < 0 }">
-                      {{ formatCurrency(profit) }}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </CCol>
-          </CRow>
-          <hr />
-          <CRow class="mt-3" v-if="accommodation.customer_data">
-            <CCol :xs="12">
-              <h6 class="text-muted">Contacto del Cliente</h6>
-              <p v-if="accommodation.customer_data.whatsapp">
-                <a :href="'https://wa.me/57' + accommodation.customer_data.whatsapp" target="_blank" class="text-success text-decoration-none">
-                  <CIcon icon="cib-whatsapp" /> {{ accommodation.customer_data.whatsapp }}
-                </a>
-              </p>
-              <p v-if="accommodation.customer_data.user_data?.email">
-                <a :href="'mailto:' + accommodation.customer_data.user_data.email" class="text-primary text-decoration-none">
-                  <CIcon icon="cil-envelope-closed" /> {{ accommodation.customer_data.user_data.email }}
-                </a>
-              </p>
-            </CCol>
-          </CRow>
-          <hr />
-          <CRow class="mt-3">
-            <CCol :xs="12">
+                </CCol>
+              </CRow>
+              <hr />
+              <CRow class="mt-3" v-if="accommodation.customer_data">
+                <CCol :xs="12">
+                  <h6 class="text-muted">Contacto del Cliente</h6>
+                  <p v-if="accommodation.customer_data.whatsapp">
+                    <a :href="'https://wa.me/57' + accommodation.customer_data.whatsapp" target="_blank" class="text-success text-decoration-none">
+                      <CIcon icon="cib-whatsapp" /> {{ accommodation.customer_data.whatsapp }}
+                    </a>
+                  </p>
+                  <p v-if="accommodation.customer_data.user_data?.email">
+                    <a :href="'mailto:' + accommodation.customer_data.user_data.email" class="text-primary text-decoration-none">
+                      <CIcon icon="cil-envelope-closed" /> {{ accommodation.customer_data.user_data.email }}
+                    </a>
+                  </p>
+                </CCol>
+              </CRow>
+
+            </CTabPane>
+
+            <!-- Tab Pagos -->
+            <CTabPane :visible="activeTab === 1">
               <div class="d-flex justify-content-between align-items-center mb-3">
                 <h5 class="mb-0">Pagos</h5>
                 <CButton color="primary" size="sm" @click="$router.push(`/business/payments/new?accommodation_id=${route.params.id}`)">
@@ -191,23 +224,22 @@
               <div v-if="payments.length > 0" class="mt-2 p-2 border rounded">
                 <strong>Total pagado:</strong> {{ formatCurrency(totalPaid) }}
               </div>
-            </CCol>
-          </CRow>
-          <hr />
-          <CRow class="mt-3">
-            <CCol :xs="12">
+            </CTabPane>
+
+            <!-- Tab Depósito -->
+            <CTabPane :visible="activeTab === 2">
               <div class="d-flex justify-content-between align-items-center mb-3">
                 <h5 class="mb-0">Depósito de Garantía</h5>
-                <CButton 
-                  v-if="!deposit" 
-                  color="primary" 
-                  size="sm" 
+                <CButton
+                  v-if="!deposit"
+                  color="primary"
+                  size="sm"
                   @click="$router.push(`/business/deposits/new?accommodation_id=${route.params.id}`)"
                 >
                   Registrar Depósito
                 </CButton>
               </div>
-              
+
               <div v-if="deposit" class="border rounded p-3">
                 <CRow>
                   <CCol :md="3">
@@ -222,8 +254,8 @@
                   </CCol>
                   <CCol :md="3">
                     <h6 class="text-muted mb-1">Estado</h6>
-                    <CBadge 
-                      :color="depositStatusColor(deposit.status)" 
+                    <CBadge
+                      :color="depositStatusColor(deposit.status)"
                       class="px-3 py-2"
                     >
                       {{ depositStatusLabel(deposit.status) }}
@@ -240,18 +272,18 @@
                       por {{ deposit.verified_by_user.name || deposit.verified_by_user.email }}
                     </div>
                     <div class="mt-2">
-                      <CButton 
+                      <CButton
                         v-if="!deposit.verified"
-                        color="success" 
-                        size="sm" 
+                        color="success"
+                        size="sm"
                         @click="verifyDeposit"
                       >
                         Verificar
                       </CButton>
-                      <CButton 
+                      <CButton
                         v-else
-                        color="warning" 
-                        size="sm" 
+                        color="warning"
+                        size="sm"
                         variant="outline"
                         @click="unverifyDeposit"
                       >
@@ -264,7 +296,7 @@
                     <p class="mb-0">{{ formatPaymentDate(deposit.payment_date) }}</p>
                   </CCol>
                 </CRow>
-                
+
                 <CRow class="mt-3" v-if="deposit.payment_method || deposit.reference">
                   <CCol :md="6" v-if="deposit.payment_method">
                     <h6 class="text-muted mb-1">Método de Pago</h6>
@@ -275,7 +307,7 @@
                     <p class="mb-0">{{ deposit.reference }}</p>
                   </CCol>
                 </CRow>
-                
+
                 <CRow class="mt-3" v-if="deposit.status === 'refunded'">
                   <CCol :md="4">
                     <h6 class="text-muted mb-1">Monto Devuelto</h6>
@@ -290,7 +322,7 @@
                     <p class="mb-0">{{ deposit.refund_reference }}</p>
                   </CCol>
                 </CRow>
-                
+
                 <CRow class="mt-3" v-if="deposit.status === 'claimed'">
                   <CCol :md="4">
                     <h6 class="text-muted mb-1">Monto Retenido</h6>
@@ -301,7 +333,7 @@
                     <p class="mb-0">{{ deposit.damage_notes }}</p>
                   </CCol>
                 </CRow>
-                
+
                 <div class="mt-3 d-flex gap-2" v-if="deposit.status === 'pending'">
                   <CButton color="success" size="sm" @click="openRefundModal">
                     Liberar Depósito
@@ -318,13 +350,13 @@
                     Eliminar Depósito
                   </CButton>
                 </div>
-                
+
                 <div class="mt-3" v-if="deposit.evidence && deposit.evidence.length > 0">
                   <h6 class="text-muted mb-2">Comprobantes</h6>
                   <div class="d-flex gap-2 flex-wrap">
-                    <div 
-                      v-for="(ev, idx) in deposit.evidence" 
-                      :key="idx" 
+                    <div
+                      v-for="(ev, idx) in deposit.evidence"
+                      :key="idx"
                       class="border rounded p-1 cursor-pointer"
                       style="cursor: pointer;"
                       @click="openEvidenceModal(ev)"
@@ -335,15 +367,14 @@
                   </div>
                 </div>
               </div>
-              
+
               <div v-else class="text-muted text-center py-3">
                 No hay depósito registrado para este hospedaje
               </div>
-            </CCol>
-          </CRow>
-          <hr />
-          <CRow class="mt-3">
-            <CCol :xs="12">
+            </CTabPane>
+
+            <!-- Tab Comisiones y Gastos -->
+            <CTabPane :visible="activeTab === 3">
               <CommissionCalculator
                 :accommodation-id="route.params.id"
                 :accommodation="accommodation"
@@ -388,20 +419,36 @@
               <div v-if="expenses.length > 0" class="mt-2 p-2 border rounded">
                 <strong>Total egresos:</strong> {{ formatCurrency(totalExpenses) }}
               </div>
-            </CCol>
-          </CRow>
+            </CTabPane>
+
+            <!-- Tab Mensajes -->
+            <CTabPane :visible="activeTab === 4">
+              <MessageSuggestions :accommodation="accommodation" />
+            </CTabPane>
+          </CTabContent>
+
+          <!-- Botones duplicados al final del contenido -->
+          <div class="mt-4 d-flex gap-2 flex-wrap justify-content-end">
+            <CButton color="warning" size="sm" @click="$router.push(`/business/accommodations/${route.params.id}/edit`)">
+              Editar
+            </CButton>
+            <CButton color="danger" size="sm" @click="onDelete">
+              Eliminar
+            </CButton>
+            <CButton color="secondary" size="sm" variant="outline" @click="$router.push('/business/accommodations')">
+              Volver
+            </CButton>
+          </div>
         </CCardBody>
         <CCardBody v-else>
           <p class="text-muted">Cargando...</p>
         </CCardBody>
       </CCard>
-
-      <MessageSuggestions v-if="accommodation" :accommodation="accommodation" />
     </CCol>
   </CRow>
 
-  <CModal 
-    :visible="showRefundModal" 
+  <CModal
+    :visible="showRefundModal"
     @close="showRefundModal = false"
     backdrop="static"
   >
@@ -414,9 +461,9 @@
       </div>
       <div class="mb-3">
         <label class="form-label">Monto a Devolver *</label>
-        <CFormInput 
-          type="number" 
-          v-model="refundForm.refund_amount" 
+        <CFormInput
+          type="number"
+          v-model="refundForm.refund_amount"
           :max="deposit?.amount"
           required
         />
@@ -454,8 +501,8 @@
     </CModalFooter>
   </CModal>
 
-  <CModal 
-    :visible="showClaimModal" 
+  <CModal
+    :visible="showClaimModal"
     @close="showClaimModal = false"
     backdrop="static"
   >
@@ -468,9 +515,9 @@
       </div>
       <div class="mb-3">
         <label class="form-label">Monto a Retener *</label>
-        <CFormInput 
-          type="number" 
-          v-model="claimForm.damage_amount" 
+        <CFormInput
+          type="number"
+          v-model="claimForm.damage_amount"
           :max="deposit?.amount"
           required
         />
@@ -478,8 +525,8 @@
       </div>
       <div class="mb-3">
         <label class="form-label">Motivo de la Retención *</label>
-        <CFormTextarea 
-          v-model="claimForm.damage_notes" 
+        <CFormTextarea
+          v-model="claimForm.damage_notes"
           rows="3"
           placeholder="Describa los daños o motivo de la retención"
           required
@@ -510,8 +557,8 @@
     </CModalFooter>
   </CModal>
 
-  <CModal 
-    :visible="showEvidenceModal" 
+  <CModal
+    :visible="showEvidenceModal"
     @close="showEvidenceModal = false"
     size="lg"
   >
@@ -519,19 +566,19 @@
       <CModalTitle>{{ selectedEvidence?.type === 'refund' ? 'Comprobante de Devolución' : selectedEvidence?.type === 'damage' ? 'Evidencia de Daño' : 'Comprobante' }}</CModalTitle>
     </CModalHeader>
     <CModalBody class="text-center">
-      <img 
-        v-if="selectedEvidence" 
-        :src="selectedEvidence.image_url" 
-        class="img-fluid rounded" 
+      <img
+        v-if="selectedEvidence"
+        :src="selectedEvidence.image_url"
+        class="img-fluid rounded"
         style="max-height: 70vh;"
       />
       <p v-if="selectedEvidence?.description" class="mt-3 text-muted">{{ selectedEvidence.description }}</p>
     </CModalBody>
   </CModal>
 
-  <CModal 
-    :visible="showReceiptModal" 
-    @close="showReceiptModal = false" 
+  <CModal
+    :visible="showReceiptModal"
+    @close="showReceiptModal = false"
     size="xl"
     :keyboard="true"
     backdrop="true"
@@ -591,9 +638,9 @@
     </CModalBody>
     <CModalFooter class="justify-content-between">
       <div>
-        <CButton 
-          v-if="selectedPayment && !selectedPayment.verified" 
-          color="warning" 
+        <CButton
+          v-if="selectedPayment && !selectedPayment.verified"
+          color="warning"
           variant="outline"
           class="me-2"
           @click="editPayment"
@@ -601,8 +648,8 @@
           <CIcon name="cil-pencil" class="me-1" />
           Editar
         </CButton>
-        <CButton 
-          v-if="selectedPayment && !selectedPayment.verified" 
+        <CButton
+          v-if="selectedPayment && !selectedPayment.verified"
           color="success"
           :disabled="verifying"
           @click="verifyPayment"
@@ -628,6 +675,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { CIcon } from '@coreui/icons-vue'
+import { CNav, CNavItem, CNavLink, CTabContent, CTabPane } from '@coreui/vue'
 import MessageSuggestions from '@/components/accommodations/MessageSuggestions.vue'
 import CommissionCalculator from '@/components/commissions/CommissionCalculator.vue'
 import { deleteAccommodation } from '@/services/accommodationService'
@@ -641,6 +689,7 @@ const selectedReceiptUrl = ref('')
 const selectedPayment = ref(null)
 const receiptLoadError = ref(false)
 const verifying = ref(false)
+const activeTab = ref(0)
 
 const expenses = ref([])
 const deposit = ref(null)
@@ -692,7 +741,7 @@ function editPayment() {
 
 async function verifyPayment() {
   if (!selectedPayment.value) return
-  
+
   verifying.value = true
   try {
     const res = await fetch(`/api/payments/${selectedPayment.value.id}/verify`, {
@@ -701,7 +750,7 @@ async function verifyPayment() {
       credentials: 'include',
       body: JSON.stringify({ verified: true })
     })
-    
+
     if (res.ok) {
       const updated = await res.json()
       selectedPayment.value = updated
@@ -723,7 +772,7 @@ async function verifyPayment() {
 
 async function verifyDeposit() {
   if (!deposit.value) return
-  
+
   try {
     const res = await fetch(`/api/deposits/${deposit.value.id}/verify`, {
       method: 'PUT',
@@ -731,7 +780,7 @@ async function verifyDeposit() {
       credentials: 'include',
       body: JSON.stringify({ verified: true })
     })
-    
+
     if (res.ok) {
       await loadDeposit()
     } else {
@@ -746,7 +795,7 @@ async function verifyDeposit() {
 
 async function unverifyDeposit() {
   if (!deposit.value) return
-  
+
   try {
     const res = await fetch(`/api/deposits/${deposit.value.id}/verify`, {
       method: 'PUT',
@@ -754,7 +803,7 @@ async function unverifyDeposit() {
       credentials: 'include',
       body: JSON.stringify({ verified: false })
     })
-    
+
     if (res.ok) {
       await loadDeposit()
     } else {
@@ -871,12 +920,12 @@ function formatDuration(seconds) {
 
 function calcCheckout(timeStr, duration, dateStr) {
   if (!timeStr || !duration || !dateStr) return '—'
-  
+
   const dateObj = new Date(dateStr)
   const year = dateObj.getUTCFullYear()
   const month = dateObj.getUTCMonth()
   const day = dateObj.getUTCDate()
-  
+
   let hours = 0, minutes = 0
   if (timeStr.includes('T')) {
     const timeDate = new Date(timeStr)
@@ -887,11 +936,11 @@ function calcCheckout(timeStr, duration, dateStr) {
     hours = h
     minutes = m
   }
-  
+
   const startMs = Date.UTC(year, month, day, hours, minutes)
   const endMs = startMs + Number(duration) * 1000
   const end = new Date(endMs)
-  
+
   return end.toLocaleDateString('es-CO', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }) +
     ' ' + String(end.getUTCHours()).padStart(2, '0') + ':' + String(end.getUTCMinutes()).padStart(2, '0')
 }
@@ -1005,17 +1054,17 @@ async function processRefund() {
     alert('Por favor complete los campos requeridos')
     return
   }
-  
+
   processingRefund.value = true
   try {
     const existingEvidence = deposit.value?.evidence || []
     const newEvidence = [...existingEvidence]
-    
+
     if (refundFile.value) {
       const ev = await uploadEvidence(refundFile.value, 'refund')
       newEvidence.push(ev)
     }
-    
+
     const res = await fetch(`/api/deposits/${deposit.value.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -1028,7 +1077,7 @@ async function processRefund() {
         evidence: newEvidence
       })
     })
-    
+
     if (res.ok) {
       showRefundModal.value = false
       await loadDeposit()
@@ -1049,17 +1098,17 @@ async function processClaim() {
     alert('Por favor complete los campos requeridos')
     return
   }
-  
+
   processingClaim.value = true
   try {
     const existingEvidence = deposit.value?.evidence || []
     const newEvidence = [...existingEvidence]
-    
+
     for (const file of claimFiles.value) {
       const ev = await uploadEvidence(file, 'damage')
       newEvidence.push(ev)
     }
-    
+
     const res = await fetch(`/api/deposits/${deposit.value.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -1071,7 +1120,7 @@ async function processClaim() {
         evidence: newEvidence
       })
     })
-    
+
     if (res.ok) {
       showClaimModal.value = false
       await loadDeposit()

--- a/src/views/venues/VenueDetail.vue
+++ b/src/views/venues/VenueDetail.vue
@@ -1,120 +1,150 @@
 <template>
   <CRow>
-    <CCol :xs="12" md="8" lg="6" class="mx-auto">
+    <CCol :xs="12">
       <CCard class="mb-4">
-        <CCardHeader>
+        <CCardHeader class="d-flex justify-content-between align-items-center">
           <strong>Detalle de la Cabaña</strong>
+          <div v-if="venue" class="d-flex gap-2 flex-wrap">
+            <RouterLink :to="`/business/venues/${venue.id}/edit`">
+              <CButton color="primary" size="sm">Editar</CButton>
+            </RouterLink>
+            <RouterLink :to="`/business/venues/${venue.id}/plans`">
+              <CButton color="success" size="sm">Planes</CButton>
+            </RouterLink>
+            <RouterLink :to="{ path: '/business/expenses', query: { venue_id: venue.id } }">
+              <CButton color="warning" size="sm">Egresos</CButton>
+            </RouterLink>
+            <RouterLink :to="{ path: '/business/expenses/create', query: { venue_id: venue.id } }">
+              <CButton color="warning" size="sm" variant="outline">+ Egreso</CButton>
+            </RouterLink>
+            <RouterLink :to="{ path: '/next', query: { venues: venue.id } }">
+              <CButton color="info" size="sm">Próximos</CButton>
+            </RouterLink>
+            <RouterLink :to="`/venues/${venue.id}/chat`">
+              <CButton color="dark" size="sm">Chat IA</CButton>
+            </RouterLink>
+            <CButton color="danger" size="sm" @click="onDelete">Eliminar</CButton>
+            <RouterLink to="/business/venues">
+              <CButton color="secondary" size="sm" variant="outline">Volver</CButton>
+            </RouterLink>
+          </div>
         </CCardHeader>
         <CCardBody>
           <template v-if="venue">
-            <p class="d-none"><strong>ID:</strong> <span class="text-body-secondary">{{ venue.id }}</span></p>
-            <p><strong>Nombre:</strong> <span class="text-body-secondary">{{ venue.name }}</span></p>
-            <p><strong>WhatsApp:</strong> <span class="text-body-secondary">{{ venue.whatsapp }}</span></p>
-            <p><strong>Instagram:</strong> <span class="text-body-secondary"><a :href="instagramUrl" target="_blank" rel="noopener noreferrer">{{ instagramDisplay }} <CIcon icon="cil-external-link" size="sm" class="ms-1" /></a></span></p>
-            <p><strong>Dirección:</strong> <span class="text-body-secondary">{{ venue.address }}</span></p>
-            <p><strong>Código Postal:</strong> <span class="text-body-secondary">{{ venue.zip_code }}</span></p>
-            <p><strong>Latitud:</strong> <span class="text-body-secondary">{{ venue.latitude }}</span></p>
-            <p><strong>Longitud:</strong> <span class="text-body-secondary">{{ venue.longitude }}</span></p>
-            <div class="mb-3">
-              <div ref="mapContainer" class="map-container"></div>
-            </div>
-            <p><strong>Ciudad:</strong> <span class="text-body-secondary">{{ venue.city }}</span></p>
-            <p><strong>País:</strong> <span class="text-body-secondary">{{ venue.country }}</span></p>
-            <p><strong>Departamento:</strong> <span class="text-body-secondary">{{ venue.department }}</span></p>
-            <p><strong>Barrio:</strong> <span class="text-body-secondary">{{ venue.suburb }}</span></p>
-            <p><strong>Referencia:</strong> <span class="text-body-secondary">{{ venue.address_reference }}</span></p>
-            
-            <!-- Navigation Links Preview -->
-            <div v-if="venue.waze_link || venue.google_maps_link" class="mb-4">
-              <strong>Navegación:</strong>
-              <CRow class="mt-2 g-3">
-                <CCol :xs="12" :sm="6" v-if="venue.waze_link">
-                  <CCard class="h-100 navigation-card">
-                    <CCardBody class="d-flex align-items-center p-3">
-                      <div class="nav-icon-wrapper bg-primary-subtle me-3">
-                        <img src="https://www.waze.com/favicon.ico" alt="Waze" width="24" height="24" />
-                      </div>
-                      <div class="flex-grow-1">
-                        <div class="fw-semibold">Waze</div>
-                        <small class="text-muted">Navegación en tiempo real</small>
-                      </div>
-                      <a :href="venue.waze_link" target="_blank" rel="noopener noreferrer" class="stretched-link">
-                        <CIcon icon="cil-external-link" />
-                      </a>
-                    </CCardBody>
-                  </CCard>
-                </CCol>
-                <CCol :xs="12" :sm="6" v-if="venue.google_maps_link">
-                  <CCard class="h-100 navigation-card">
-                    <CCardBody class="d-flex align-items-center p-3">
-                      <div class="nav-icon-wrapper bg-success-subtle me-3">
-                        <img src="https://maps.google.com/favicon.ico" alt="Google Maps" width="24" height="24" />
-                      </div>
-                      <div class="flex-grow-1">
-                        <div class="fw-semibold">Google Maps</div>
-                        <small class="text-muted">Ver en el mapa</small>
-                      </div>
-                      <a :href="googleMapsUrl" target="_blank" rel="noopener noreferrer" class="stretched-link">
-                        <CIcon icon="cil-external-link" />
-                      </a>
-                    </CCardBody>
-                  </CCard>
-                </CCol>
-              </CRow>
-            </div>
-            
-            <!-- Galería de imágenes -->
-            <div v-if="venueImages.length > 0" class="mb-4">
-              <strong>Fotos:</strong>
-              <div class="mt-2">
-                <div v-if="coverImage" class="cover-image-wrapper mb-3">
-                  <img :src="coverImage.image_url" class="img-fluid rounded" alt="Portada" />
-                </div>
-                <div v-if="thumbnailImages.length > 0" class="venue-thumbnails">
-                  <img
-                    v-for="image in thumbnailImages"
-                    :key="image.id"
-                    :src="image.image_url"
-                    class="img-thumbnail venue-thumb"
-                    alt="Foto de la cabaña"
-                  />
-                </div>
-              </div>
-            </div>
+            <CNav variant="tabs" class="mb-3">
+              <CNavItem>
+                <CNavLink href="javascript:void(0)" :active="activeTab === 0" @click="activeTab = 0">
+                  Información
+                </CNavLink>
+              </CNavItem>
+              <CNavItem>
+                <CNavLink href="javascript:void(0)" :active="activeTab === 1" @click="activeTab = 1">
+                  Ubicación
+                </CNavLink>
+              </CNavItem>
+              <CNavItem>
+                <CNavLink href="javascript:void(0)" :active="activeTab === 2" @click="activeTab = 2">
+                  Galería
+                </CNavLink>
+              </CNavItem>
+            </CNav>
 
-            <div v-if="venueAmenities.length > 0" class="mb-4">
-              <strong>Amenidades:</strong>
-              <div class="d-flex flex-wrap gap-1 mt-2">
-                <CBadge v-for="amenity in venueAmenities" :key="amenity.id" color="info" class="me-1">
-                  {{ amenity.name }}
-                </CBadge>
-              </div>
-            </div>
-            
-            <div class="mt-4 d-flex flex-wrap gap-2">
-              <RouterLink :to="`/business/venues/${venue.id}/edit`">
-                <CButton color="primary" size="sm">Editar</CButton>
-              </RouterLink>
-              <RouterLink :to="`/business/venues/${venue.id}/plans`">
-                <CButton color="success" size="sm">Planes</CButton>
-              </RouterLink>
-              <RouterLink :to="{ path: '/business/expenses', query: { venue_id: venue.id } }">
-                <CButton color="warning" size="sm">Egresos</CButton>
-              </RouterLink>
-              <RouterLink :to="{ path: '/business/expenses/create', query: { venue_id: venue.id } }">
-                <CButton color="warning" size="sm" variant="outline">+ Egreso</CButton>
-              </RouterLink>
-              <RouterLink :to="{ path: '/next', query: { venues: venue.id } }">
-                <CButton color="info" size="sm">Próximos</CButton>
-              </RouterLink>
-              <RouterLink :to="`/venues/${venue.id}/chat`">
-                <CButton color="dark" size="sm">Chat IA</CButton>
-              </RouterLink>
-              <CButton color="danger" size="sm" @click="onDelete">Eliminar</CButton>
-              <RouterLink to="/business/venues">
-                <CButton color="secondary" size="sm" variant="outline">Volver a la Lista</CButton>
-              </RouterLink>
-            </div>
+            <CTabContent>
+              <!-- Tab Información -->
+              <CTabPane :visible="activeTab === 0">
+                <p class="d-none"><strong>ID:</strong> <span class="text-body-secondary">{{ venue.id }}</span></p>
+                <p><strong>Nombre:</strong> <span class="text-body-secondary">{{ venue.name }}</span></p>
+                <p><strong>WhatsApp:</strong> <span class="text-body-secondary">{{ venue.whatsapp }}</span></p>
+                <p><strong>Instagram:</strong> <span class="text-body-secondary"><a :href="instagramUrl" target="_blank" rel="noopener noreferrer">{{ instagramDisplay }} <CIcon icon="cil-external-link" size="sm" class="ms-1" /></a></span></p>
+                <p><strong>Dirección:</strong> <span class="text-body-secondary">{{ venue.address }}</span></p>
+                <p><strong>Código Postal:</strong> <span class="text-body-secondary">{{ venue.zip_code }}</span></p>
+                <p><strong>Latitud:</strong> <span class="text-body-secondary">{{ venue.latitude }}</span></p>
+                <p><strong>Longitud:</strong> <span class="text-body-secondary">{{ venue.longitude }}</span></p>
+                <p><strong>Ciudad:</strong> <span class="text-body-secondary">{{ venue.city }}</span></p>
+                <p><strong>País:</strong> <span class="text-body-secondary">{{ venue.country }}</span></p>
+                <p><strong>Departamento:</strong> <span class="text-body-secondary">{{ venue.department }}</span></p>
+                <p><strong>Barrio:</strong> <span class="text-body-secondary">{{ venue.suburb }}</span></p>
+                <p><strong>Referencia:</strong> <span class="text-body-secondary">{{ venue.address_reference }}</span></p>
+              </CTabPane>
+
+              <!-- Tab Ubicación -->
+              <CTabPane :visible="activeTab === 1">
+                <div class="mb-3">
+                  <div ref="mapContainer" class="map-container"></div>
+                </div>
+
+                <div v-if="venue.waze_link || venue.google_maps_link" class="mb-4">
+                  <strong>Navegación:</strong>
+                  <CRow class="mt-2 g-3">
+                    <CCol :xs="12" :sm="6" v-if="venue.waze_link">
+                      <CCard class="h-100 navigation-card">
+                        <CCardBody class="d-flex align-items-center p-3">
+                          <div class="nav-icon-wrapper bg-primary-subtle me-3">
+                            <img src="https://www.waze.com/favicon.ico" alt="Waze" width="24" height="24" />
+                          </div>
+                          <div class="flex-grow-1">
+                            <div class="fw-semibold">Waze</div>
+                            <small class="text-muted">Navegación en tiempo real</small>
+                          </div>
+                          <a :href="venue.waze_link" target="_blank" rel="noopener noreferrer" class="stretched-link">
+                            <CIcon icon="cil-external-link" />
+                          </a>
+                        </CCardBody>
+                      </CCard>
+                    </CCol>
+                    <CCol :xs="12" :sm="6" v-if="venue.google_maps_link">
+                      <CCard class="h-100 navigation-card">
+                        <CCardBody class="d-flex align-items-center p-3">
+                          <div class="nav-icon-wrapper bg-success-subtle me-3">
+                            <img src="https://maps.google.com/favicon.ico" alt="Google Maps" width="24" height="24" />
+                          </div>
+                          <div class="flex-grow-1">
+                            <div class="fw-semibold">Google Maps</div>
+                            <small class="text-muted">Ver en el mapa</small>
+                          </div>
+                          <a :href="googleMapsUrl" target="_blank" rel="noopener noreferrer" class="stretched-link">
+                            <CIcon icon="cil-external-link" />
+                          </a>
+                        </CCardBody>
+                      </CCard>
+                    </CCol>
+                  </CRow>
+                </div>
+              </CTabPane>
+
+              <!-- Tab Galería -->
+              <CTabPane :visible="activeTab === 2">
+                <div v-if="venueImages.length > 0" class="mb-4">
+                  <strong>Fotos:</strong>
+                  <div class="mt-2">
+                    <div v-if="coverImage" class="cover-image-wrapper mb-3">
+                      <img :src="coverImage.image_url" class="img-fluid rounded" alt="Portada" />
+                    </div>
+                    <div v-if="thumbnailImages.length > 0" class="venue-thumbnails">
+                      <img
+                        v-for="image in thumbnailImages"
+                        :key="image.id"
+                        :src="image.image_url"
+                        class="img-thumbnail venue-thumb"
+                        alt="Foto de la cabaña"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div v-else class="text-muted text-center py-3">
+                  No hay fotos cargadas
+                </div>
+
+                <div v-if="venueAmenities.length > 0" class="mb-4">
+                  <strong>Amenidades:</strong>
+                  <div class="d-flex flex-wrap gap-1 mt-2">
+                    <CBadge v-for="amenity in venueAmenities" :key="amenity.id" color="info" class="me-1">
+                      {{ amenity.name }}
+                    </CBadge>
+                  </div>
+                </div>
+              </CTabPane>
+            </CTabContent>
           </template>
           <template v-else>
             <CSpinner color="primary" /> Cargando...
@@ -128,7 +158,7 @@
 <script setup>
 import { ref, onMounted, watch, nextTick, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { CRow, CCol, CCard, CCardHeader, CCardBody, CButton, CSpinner, CBadge } from '@coreui/vue'
+import { CRow, CCol, CCard, CCardHeader, CCardBody, CButton, CSpinner, CBadge, CNav, CNavItem, CNavLink, CTabContent, CTabPane } from '@coreui/vue'
 import { CIcon } from '@coreui/icons-vue'
 import { getVenueById, deleteVenue } from '@/services/venueService'
 import { useBreadcrumbStore } from '@/stores/breadcrumb.js'
@@ -143,6 +173,8 @@ const venueAmenities = ref([])
 const venueImages = ref([])
 const mapContainer = ref(null)
 const token = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN
+const activeTab = ref(0)
+const mapInitialized = ref(false)
 
 const instagramUrl = computed(() => {
   const ig = venue.value?.instagram || ''
@@ -210,20 +242,33 @@ const onDelete = async () => {
   }
 }
 
-watch(venue, async (val) => {
+function initMap() {
+  if (mapInitialized.value || !venue.value || !venue.value.latitude || !venue.value.longitude) return
+  if (!mapContainer.value) return
+  mapboxgl.accessToken = token
+  const map = new mapboxgl.Map({
+    style: 'mapbox://styles/mapbox/streets-v11',
+    container: mapContainer.value,
+    center: [venue.value.longitude, venue.value.latitude],
+    zoom: 12
+  })
+  new mapboxgl.Marker().setLngLat([venue.value.longitude, venue.value.latitude]).addTo(map)
+  mapInitialized.value = true
+}
+
+watch(venue, (val) => {
   if (val) {
     breadcrumbStore.setTitle(`Detalle ${val.name}`)
-    if (val.latitude && val.longitude) {
-      await nextTick()
-      mapboxgl.accessToken = token
-      const map = new mapboxgl.Map({
-        style: 'mapbox://styles/mapbox/streets-v11',
-        container: mapContainer.value,
-        center: [val.longitude, val.latitude],
-        zoom: 12
-      })
-      new mapboxgl.Marker().setLngLat([val.longitude, val.latitude]).addTo(map)
+    if (activeTab.value === 1) {
+      nextTick(() => initMap())
     }
+  }
+})
+
+watch(activeTab, async (tab) => {
+  if (tab === 1 && venue.value) {
+    await nextTick()
+    initMap()
   }
 })
 </script>


### PR DESCRIPTION
## Summary
- **VenueDetail**: Full width layout, contenido organizado en 3 tabs (Información, Ubicación, Galería), 8 botones movidos al header, mapa Mapbox con lazy-init al activar tab
- **AccommodationDetail**: Contenido reorganizado en 5 tabs (Resumen, Pagos, Depósito, Comisiones y Gastos, Mensajes), botones duplicados al fondo para fácil acceso

## Test plan
- [ ] Navegar a `/business/venues/:id` — verificar 3 tabs, botones arriba, mapa carga en tab Ubicación
- [ ] Navegar a `/business/accommodations/:id` — verificar 5 tabs, botones arriba y abajo
- [ ] Probar modales: registrar pago, devolución depósito, reclamo depósito, ver evidencia
- [ ] Verificar responsive en móvil (tabs wrap, botones no se salen)
- [ ] Verificar mapa Mapbox se renderiza al cambiar al tab Ubicación

🤖 Generated with [Claude Code](https://claude.com/claude-code)