### PR TITLE
feat: WhatsApp payment flow (QR + receipt verification)

### DIFF
--- a/microservices/whatsapp-baileys/prisma/schema.prisma
+++ b/microservices/whatsapp-baileys/prisma/schema.prisma
@@ -53,6 +53,31 @@ model chat_conversations {
   updated_at       DateTime? @db.Timestamptz(6)
 }
 
+model chat_messages {
+  id              String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  conversation_id String   @db.Uuid
+  role            String   @db.VarChar(20)
+  content         String
+  status          String?  @db.VarChar(20)
+  error_details   String?
+  external_id     String?  @db.VarChar(255)
+  created_at      DateTime @default(now()) @db.Timestamptz(6)
+}
+
+model whatsapp_event_log {
+  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  venue_id   String?  @db.Uuid
+  event_type String   @db.VarChar(50)
+  details    String?
+  phone      String?  @db.VarChar(50)
+  message_id String?  @db.Uuid
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+
+  @@index([venue_id])
+  @@index([event_type])
+  @@index([created_at])
+}
+
 model venues {
   id       String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   name     String?  @db.VarChar

--- a/microservices/whatsapp-baileys/src/routes/health.js
+++ b/microservices/whatsapp-baileys/src/routes/health.js
@@ -16,6 +16,33 @@ router.get('/health', async (req, res) => {
     components.database = { status: 'down', error: err.message };
   }
 
+  // Gather per-venue details
+  const venueDetails = {};
+  for (const [vid, entry] of baileysService.connections) {
+    const detail = { phone: entry.phoneNumber || null };
+    if (components.database.status === 'up') {
+      try {
+        const lastMsg = await prisma.chat_messages.findFirst({
+          where: {
+            conversation: { venue_id: vid, source: 'baileys' },
+            role: 'assistant'
+          },
+          orderBy: { created_at: 'desc' },
+          select: { created_at: true, status: true }
+        });
+        detail.last_message_at = lastMsg?.created_at || null;
+        detail.last_message_status = lastMsg?.status || null;
+
+        const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+        const recentErrors = await prisma.whatsapp_event_log.count({
+          where: { venue_id: vid, event_type: { in: ['message_failed', 'error'] }, created_at: { gte: oneHourAgo } }
+        });
+        detail.recent_errors_1h = recentErrors;
+      } catch (_) {}
+    }
+    venueDetails[vid] = detail;
+  }
+
   const dbUp = components.database.status === 'up';
   const status = dbUp ? 'healthy' : 'unhealthy';
 
@@ -23,6 +50,7 @@ router.get('/health', async (req, res) => {
     status,
     uptime: process.uptime(),
     venue_connections: venueConnections,
+    venue_details: venueDetails,
     components,
     timestamp: new Date().toISOString()
   });

--- a/microservices/whatsapp-baileys/src/routes/messaging.js
+++ b/microservices/whatsapp-baileys/src/routes/messaging.js
@@ -18,6 +18,21 @@ router.post('/send/venue', async (req, res) => {
   }
 });
 
+// POST /api/send/venue/image — send image from a venue's WhatsApp
+router.post('/send/venue/image', async (req, res) => {
+  try {
+    const { venueId, phone, imageUrl, caption } = req.body;
+    if (!venueId || !phone || !imageUrl) {
+      return res.status(400).json({ error: 'Missing venueId, phone, or imageUrl' });
+    }
+    await baileysService.sendImage(venueId, phone, imageUrl, caption);
+    res.json({ success: true });
+  } catch (error) {
+    console.error('[messaging] Venue image send error:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // POST /api/send/system — send message from system WhatsApp
 router.post('/send/system', async (req, res) => {
   try {

--- a/microservices/whatsapp-baileys/src/services/baileysHandler.js
+++ b/microservices/whatsapp-baileys/src/services/baileysHandler.js
@@ -124,14 +124,37 @@ async function handleMessage(venueId, socket, message) {
 
     const data = await response.json();
     const replyText = data.response || data.message;
+    const assistantMessageId = data.assistant_message_id;
 
     if (!replyText) {
       console.warn(`[baileys] No response text from chat API for venue ${venueId}`);
       return;
     }
 
-    await socket.sendMessage(remoteJid, { text: replyText });
-    console.log(`[baileys] Replied to ${senderPhone} for venue ${venueId}`);
+    try {
+      const sentMsg = await socket.sendMessage(remoteJid, { text: replyText });
+      console.log(`[baileys] Replied to ${senderPhone} for venue ${venueId}`);
+
+      // Report 'sent' status + external_id to main app
+      if (assistantMessageId && config.MAIN_APP_INTERNAL_KEY) {
+        updateMessageStatus(assistantMessageId, 'sent', sentMsg?.key?.id).catch(err =>
+          console.error('[baileys] Failed to report sent status:', err.message)
+        );
+        logEvent(venueId, 'message_sent', null, senderPhone).catch(() => {});
+      }
+    } catch (sendErr) {
+      console.error(`[baileys] Failed to send message for venue ${venueId}:`, sendErr.message);
+      // Report 'failed' status
+      if (assistantMessageId && config.MAIN_APP_INTERNAL_KEY) {
+        updateMessageStatus(assistantMessageId, 'failed', null, sendErr.message).catch(err =>
+          console.error('[baileys] Failed to report failed status:', err.message)
+        );
+        logEvent(venueId, 'message_failed', sendErr.message, senderPhone).catch(() => {});
+      }
+    }
+
+    // Log incoming message event
+    logEvent(venueId, 'message_received', null, senderPhone).catch(() => {});
   } catch (err) {
     console.error('[baileys] Error handling message:', err);
   }
@@ -147,4 +170,46 @@ function extractText(message) {
   return null;
 }
 
-module.exports = { handleMessage, extractText };
+/**
+ * Update message delivery status on the main app.
+ */
+async function updateMessageStatus(messageId, status, externalId, errorDetails) {
+  const url = `${config.MAIN_APP_URL}/api/chat/messages/${messageId}/status`;
+  const body = { status };
+  if (externalId) body.external_id = externalId;
+  if (errorDetails) body.error_details = errorDetails;
+
+  await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-Key': config.MAIN_APP_INTERNAL_KEY
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+/**
+ * Log a WhatsApp event to the main app.
+ */
+async function logEvent(venueId, eventType, details, phone, messageId) {
+  const url = `${config.MAIN_APP_URL}/api/whatsapp/events`;
+  const body = {
+    venue_id: venueId,
+    event_type: eventType,
+    details: details || undefined,
+    phone: phone || undefined,
+    message_id: messageId || undefined
+  };
+
+  await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-Key': config.MAIN_APP_INTERNAL_KEY
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+module.exports = { handleMessage, extractText, updateMessageStatus, logEvent };

--- a/microservices/whatsapp-baileys/src/services/baileysHandler.js
+++ b/microservices/whatsapp-baileys/src/services/baileysHandler.js
@@ -4,6 +4,7 @@
  * Calls the main app's chat API via MAIN_APP_URL instead of localhost.
  */
 
+const { downloadMediaMessage } = require('baileys');
 const { prisma } = require('../db');
 const config = require('../config');
 
@@ -20,8 +21,43 @@ async function handleMessage(venueId, socket, message) {
     if (remoteJid.endsWith('@g.us')) return;
     if (msg.key?.fromMe) return;
 
+    // Handle image messages
+    let mediaUrl = null;
+    let mediaType = null;
+    if (msg.message?.imageMessage) {
+      try {
+        const buffer = await downloadMediaMessage(msg, 'buffer', {});
+        // Upload to main app
+        const uploadUrl = `${config.MAIN_APP_URL}/api/uploads/chat-media`;
+        const formData = new FormData();
+        formData.append('file', new Blob([buffer], { type: 'image/jpeg' }), 'image.jpg');
+
+        const uploadHeaders = {};
+        if (config.MAIN_APP_INTERNAL_KEY) {
+          uploadHeaders['X-Internal-Key'] = config.MAIN_APP_INTERNAL_KEY;
+        }
+
+        const uploadRes = await fetch(uploadUrl, {
+          method: 'POST',
+          headers: uploadHeaders,
+          body: formData
+        });
+
+        if (uploadRes.ok) {
+          const uploadData = await uploadRes.json();
+          mediaUrl = uploadData.url;
+          mediaType = 'image';
+          console.log(`[baileys] Image uploaded for venue ${venueId}: ${mediaUrl}`);
+        } else {
+          console.error('[baileys] Failed to upload image:', await uploadRes.text());
+        }
+      } catch (imgErr) {
+        console.error('[baileys] Error downloading/uploading image:', imgErr.message);
+      }
+    }
+
     const messageText = extractText(msg.message);
-    if (!messageText) return;
+    if (!messageText && !mediaUrl) return;
 
     const senderPhone = remoteJid.replace('@s.whatsapp.net', '');
     const pushName = msg.pushName || null;
@@ -60,11 +96,13 @@ async function handleMessage(venueId, socket, message) {
     // Call the main app's chat API via HTTP
     const chatUrl = `${config.MAIN_APP_URL}/api/chat/${venueId}`;
     const body = {
-      message: messageText,
+      message: messageText || (mediaUrl ? '[Imagen]' : ''),
       source: 'baileys',
       visitor_phone: senderPhone,
       visitor_name: pushName,
-      conversation_id: conversationId
+      conversation_id: conversationId,
+      media_url: mediaUrl || undefined,
+      media_type: mediaType || undefined
     };
 
     const headers = { 'Content-Type': 'application/json' };

--- a/microservices/whatsapp-baileys/src/services/baileysService.js
+++ b/microservices/whatsapp-baileys/src/services/baileysService.js
@@ -186,6 +186,15 @@ async function sendMessage(venueId, phone, text) {
   await entry.socket.sendMessage(jid, { text });
 }
 
+async function sendImage(venueId, phone, imageUrl, caption) {
+  const entry = connections.get(venueId);
+  if (!entry?.socket) {
+    throw new Error('No active WhatsApp connection for this venue');
+  }
+  const jid = phone.includes('@') ? phone : `${phone}@s.whatsapp.net`;
+  await entry.socket.sendMessage(jid, { image: { url: imageUrl }, caption: caption || '' });
+}
+
 async function restoreAllConnections() {
   try {
     const activeConnections = await prisma.whatsapp_connections.findMany({
@@ -215,6 +224,7 @@ module.exports = {
   disconnectVenue,
   getStatus,
   sendMessage,
+  sendImage,
   restoreAllConnections,
   connections
 };

--- a/microservices/whatsapp-baileys/src/services/baileysService.js
+++ b/microservices/whatsapp-baileys/src/services/baileysService.js
@@ -9,7 +9,7 @@ const { default: makeWASocket, DisconnectReason, fetchLatestBaileysVersion } = r
 const { Boom } = require('@hapi/boom');
 const { prisma } = require('../db');
 const { useDBAuthState } = require('../stores/baileysStore');
-const { handleMessage } = require('./baileysHandler');
+const { handleMessage, logEvent } = require('./baileysHandler');
 
 const connections = new Map();
 const retryCounts = new Map();
@@ -58,6 +58,7 @@ async function connectVenue(venueId) {
         where: { venue_id: venueId },
         data: { qr_code: qr, status: 'qr_pending', updated_at: new Date() }
       });
+      logEvent(venueId, 'qr_generated').catch(() => {});
     }
 
     if (connection === 'open') {
@@ -79,12 +80,14 @@ async function connectVenue(venueId) {
       const entry = connections.get(venueId);
       if (entry) entry.phoneNumber = phoneNumber;
       retryCounts.set(venueId, 0);
+      logEvent(venueId, 'connected', null, phoneNumber).catch(() => {});
     }
 
     if (connection === 'close') {
       const statusCode = new Boom(lastDisconnect?.error)?.output?.statusCode;
       const shouldReconnect = statusCode !== DisconnectReason.loggedOut;
       console.log(`[baileys] Connection closed for venue ${venueId}, code: ${statusCode}, reconnect: ${shouldReconnect}`);
+      logEvent(venueId, 'disconnected', JSON.stringify({ statusCode, reason: lastDisconnect?.error?.message })).catch(() => {});
 
       if (statusCode === DisconnectReason.loggedOut) {
         await prisma.whatsapp_connections.update({
@@ -109,6 +112,7 @@ async function connectVenue(venueId) {
           setTimeout(() => connectVenue(venueId), delay);
         } else {
           console.error(`[baileys] Max retries reached for venue ${venueId}`);
+          logEvent(venueId, 'max_retries_reached', JSON.stringify({ retries: MAX_RETRIES })).catch(() => {});
           await prisma.whatsapp_connections.update({
             where: { venue_id: venueId },
             data: { status: 'disconnected', qr_code: null, updated_at: new Date() }
@@ -126,6 +130,24 @@ async function connectVenue(venueId) {
     if (type !== 'notify') return;
     for (const msg of msgs) {
       await handleMessage(venueId, socket, msg);
+    }
+  });
+
+  // Track message delivery/read status updates from WhatsApp
+  socket.ev.on('messages.update', async (updates) => {
+    for (const update of updates) {
+      try {
+        const waStatus = update.update?.status;
+        const statusMap = { 2: 'sent', 3: 'delivered', 4: 'read' };
+        if (statusMap[waStatus] && update.key?.id) {
+          await prisma.chat_messages.updateMany({
+            where: { external_id: update.key.id },
+            data: { status: statusMap[waStatus] }
+          });
+        }
+      } catch (err) {
+        // Silently ignore — external_id may not exist for non-tracked messages
+      }
     }
   });
 

--- a/server/index.js
+++ b/server/index.js
@@ -6582,6 +6582,164 @@ REGLAS:
     }
   });
 
+  // ==================== WhatsApp Message Tracking & Events ====================
+
+  // PATCH /api/chat/messages/:id/status - Update message delivery status (internal key auth)
+  app.patch('/api/chat/messages/:id/status', async (req, res) => {
+    try {
+      const internalKey = req.headers['x-internal-key'];
+      if (!internalKey || internalKey !== process.env.WHATSAPP_INTERNAL_KEY) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { id } = req.params;
+      const { status, external_id, error_details } = req.body;
+
+      if (!status) {
+        return res.status(400).json({ error: 'status is required' });
+      }
+
+      const validStatuses = ['pending', 'sent', 'delivered', 'read', 'failed'];
+      if (!validStatuses.includes(status)) {
+        return res.status(400).json({ error: `Invalid status. Must be one of: ${validStatuses.join(', ')}` });
+      }
+
+      const updateData = { status };
+      if (external_id) updateData.external_id = external_id;
+      if (error_details) updateData.error_details = error_details;
+
+      await prisma.chat_messages.update({
+        where: { id },
+        data: updateData
+      });
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('[message-status] Error:', error.message);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // POST /api/whatsapp/events - Log WhatsApp events (internal key auth)
+  app.post('/api/whatsapp/events', async (req, res) => {
+    try {
+      const internalKey = req.headers['x-internal-key'];
+      if (!internalKey || internalKey !== process.env.WHATSAPP_INTERNAL_KEY) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { venue_id, event_type, details, phone, message_id } = req.body;
+
+      if (!event_type) {
+        return res.status(400).json({ error: 'event_type is required' });
+      }
+
+      await prisma.whatsapp_event_log.create({
+        data: {
+          venue_id: venue_id || null,
+          event_type,
+          details: details ? (typeof details === 'string' ? details : JSON.stringify(details)) : null,
+          phone: phone || null,
+          message_id: message_id || null
+        }
+      });
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('[whatsapp-events] Error:', error.message);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // GET /api/venues/:id/whatsapp/events - Get recent WhatsApp events for a venue
+  app.get('/api/venues/:id/whatsapp/events', isAuthenticated, async (req, res) => {
+    try {
+      const { id } = req.params;
+      const limit = parseInt(req.query.limit) || 50;
+
+      const events = await prisma.whatsapp_event_log.findMany({
+        where: { venue_id: id },
+        orderBy: { created_at: 'desc' },
+        take: Math.min(limit, 200)
+      });
+
+      res.json(events);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // GET /api/venues/:id/whatsapp/stats - Get message stats for a venue
+  app.get('/api/venues/:id/whatsapp/stats', isAuthenticated, async (req, res) => {
+    try {
+      const { id } = req.params;
+
+      // Get conversations for this venue with source baileys
+      const conversations = await prisma.chat_conversations.findMany({
+        where: { venue_id: id, source: 'baileys' },
+        select: { id: true }
+      });
+      const convIds = conversations.map(c => c.id);
+
+      if (convIds.length === 0) {
+        return res.json({
+          total_sent: 0, total_delivered: 0, total_read: 0,
+          total_failed: 0, total_pending: 0,
+          last_message_at: null, failed_details: []
+        });
+      }
+
+      // Count messages by status for assistant messages (outbound)
+      const statusCounts = await prisma.chat_messages.groupBy({
+        by: ['status'],
+        where: {
+          conversation_id: { in: convIds },
+          role: 'assistant',
+          status: { not: null }
+        },
+        _count: { id: true }
+      });
+
+      const counts = {};
+      for (const sc of statusCounts) {
+        counts[sc.status] = sc._count.id;
+      }
+
+      // Last message
+      const lastMessage = await prisma.chat_messages.findFirst({
+        where: { conversation_id: { in: convIds }, role: 'assistant' },
+        orderBy: { created_at: 'desc' },
+        select: { created_at: true, status: true }
+      });
+
+      // Recent failed messages (last 24h)
+      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const failedMessages = await prisma.chat_messages.findMany({
+        where: {
+          conversation_id: { in: convIds },
+          role: 'assistant',
+          status: 'failed',
+          created_at: { gte: oneDayAgo }
+        },
+        select: { id: true, error_details: true, created_at: true },
+        orderBy: { created_at: 'desc' },
+        take: 10
+      });
+
+      res.json({
+        total_sent: counts.sent || 0,
+        total_delivered: counts.delivered || 0,
+        total_read: counts.read || 0,
+        total_failed: counts.failed || 0,
+        total_pending: counts.pending || 0,
+        last_message_at: lastMessage?.created_at || null,
+        failed_details: failedMessages
+      });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
   // ==================== System WhatsApp (Admin) ====================
 
   // GET /api/admin/system-whatsapp/status
@@ -6792,7 +6950,8 @@ REGLAS:
           role: 'user',
           content: userMessage,
           media_url: media_url || null,
-          media_type: media_type || null
+          media_type: media_type || null,
+          status: source === 'baileys' ? 'delivered' : null
         }
       });
 
@@ -7575,7 +7734,8 @@ REGLAS:
           content: messageContent,
           provider: chatProviderCode,
           model: llmResponse.model,
-          tokens_used: llmResponse.usage?.total_tokens
+          tokens_used: llmResponse.usage?.total_tokens,
+          status: source === 'baileys' ? 'pending' : null
         }
       });
       
@@ -7614,6 +7774,7 @@ REGLAS:
 
       res.json({
         conversation_id: conversation.id,
+        assistant_message_id: assistantMessage.id,
         message: llmResponse.content,
         provider: chatProviderCode,
         model: llmResponse.model,

--- a/server/index.js
+++ b/server/index.js
@@ -364,6 +364,26 @@ async function startServer() {
     }
   });
 
+  // Upload chat media (internal key auth for microservice, or authenticated user)
+  app.post('/api/uploads/chat-media', upload.single('file'), async (req, res) => {
+    try {
+      // Auth: either internal key or authenticated user
+      const internalKey = req.headers['x-internal-key'];
+      const isInternalAuth = internalKey && internalKey === process.env.WHATSAPP_INTERNAL_KEY;
+      if (!isInternalAuth && !req.user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      if (!req.file) {
+        return res.status(400).json({ error: 'No file provided' });
+      }
+      const result = await uploadImage(req.file.buffer, { type: 'chat_media', mimetype: req.file.mimetype });
+      res.json({ url: result.secure_url });
+    } catch (error) {
+      console.error('Error uploading chat media:', error);
+      res.status(500).json({ error: 'Error uploading image' });
+    }
+  });
+
   app.get('/api/organizations', async (req, res) => {
     try {
       const viewAll = req.query.viewAll === 'true';
@@ -559,8 +579,8 @@ async function startServer() {
         return res.status(404).json({ error: 'Venue not found' });
       }
 
-      // Load images, amenities, and plans in parallel
-      const [images, venueAmenityLinks, plans] = await Promise.all([
+      // Load images, amenities, plans, and payment methods in parallel
+      const [images, venueAmenityLinks, plans, paymentMethods] = await Promise.all([
         prisma.venue_images.findMany({
           where: { venue_id: venue.id },
           orderBy: { sort_order: 'asc' }
@@ -571,6 +591,11 @@ async function startServer() {
         prisma.venue_plans.findMany({
           where: { venue_id: venue.id, is_active: true },
           orderBy: { name: 'asc' }
+        }),
+        prisma.venue_payment_methods.findMany({
+          where: { venue_id: venue.id, is_active: true },
+          orderBy: { sort_order: 'asc' },
+          select: { id: true, method_type: true, label: true, account_info: true, holder_name: true, qr_image_url: true, instructions: true }
         })
       ]);
 
@@ -616,7 +641,8 @@ async function startServer() {
         },
         images,
         amenities,
-        plans: plansWithAmenities
+        plans: plansWithAmenities,
+        paymentMethods
       });
     } catch (error) {
       res.status(500).json({ error: error.message });
@@ -961,6 +987,9 @@ async function startServer() {
       if (data.deposit_refund_hours !== undefined) {
         data.deposit_refund_hours = data.deposit_refund_hours ? parseInt(data.deposit_refund_hours, 10) : null;
       }
+      if (data.commission_percentage !== undefined) {
+        data.commission_percentage = data.commission_percentage ? parseFloat(data.commission_percentage) : null;
+      }
 
       // Auto-generate slug when is_public=true and slug is empty
       if (data.is_public && !data.slug && data.name) {
@@ -1039,6 +1068,156 @@ async function startServer() {
       }
       
       res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // ========================================
+  // VENUE PAYMENT METHODS
+  // ========================================
+
+  const PAYMENT_METHOD_CATALOG = [
+    { type: 'nequi', label: 'Nequi', icon: 'cil-phone' },
+    { type: 'daviplata', label: 'Daviplata', icon: 'cil-phone' },
+    { type: 'bancolombia', label: 'Bancolombia', icon: 'cil-institution' },
+    { type: 'davivienda', label: 'Davivienda', icon: 'cil-institution' },
+    { type: 'breb', label: 'Bre-B', icon: 'cil-mobile' },
+    { type: 'pse', label: 'PSE', icon: 'cil-laptop' },
+    { type: 'credit_card_national', label: 'Tarjeta de Crédito Nacional', icon: 'cil-credit-card' },
+    { type: 'credit_card_international', label: 'Tarjeta de Crédito Internacional', icon: 'cil-credit-card' },
+    { type: 'cash', label: 'Efectivo', icon: 'cil-dollar' },
+    { type: 'custom', label: 'Otro', icon: 'cil-options' }
+  ];
+
+  app.get('/api/venues/:id/payment-methods/catalog', isAuthenticated, async (req, res) => {
+    res.json(PAYMENT_METHOD_CATALOG);
+  });
+
+  app.get('/api/venues/:id/payment-methods', isAuthenticated, async (req, res) => {
+    try {
+      const methods = await prisma.venue_payment_methods.findMany({
+        where: { venue_id: req.params.id },
+        orderBy: { sort_order: 'asc' }
+      });
+      res.json(methods);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  app.post('/api/venues/:id/payment-methods', isAuthenticated, upload.single('qr_image'), async (req, res) => {
+    try {
+      const { method_type, label, account_info, holder_name, instructions, is_active } = req.body;
+      let qr_image_url = req.body.qr_image_url || null;
+
+      if (req.file) {
+        const result = await uploadImage(req.file.buffer, { type: 'payment_method', mimetype: req.file.mimetype });
+        qr_image_url = result.secure_url;
+      }
+
+      const maxOrder = await prisma.venue_payment_methods.aggregate({
+        where: { venue_id: req.params.id },
+        _max: { sort_order: true }
+      });
+
+      const method = await prisma.venue_payment_methods.create({
+        data: {
+          venue_id: req.params.id,
+          method_type,
+          label,
+          account_info: account_info || null,
+          holder_name: holder_name || null,
+          qr_image_url,
+          instructions: instructions || null,
+          is_active: is_active !== 'false',
+          sort_order: (maxOrder._max.sort_order || 0) + 1
+        }
+      });
+      res.json(method);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  app.put('/api/venues/:id/payment-methods/:methodId', isAuthenticated, upload.single('qr_image'), async (req, res) => {
+    try {
+      const { method_type, label, account_info, holder_name, instructions, is_active } = req.body;
+      const data = {
+        method_type,
+        label,
+        account_info: account_info || null,
+        holder_name: holder_name || null,
+        instructions: instructions || null,
+        is_active: is_active !== 'false',
+        updated_at: new Date()
+      };
+
+      if (req.file) {
+        // Delete old QR if exists
+        const existing = await prisma.venue_payment_methods.findUnique({ where: { id: req.params.methodId } });
+        if (existing?.qr_image_url) {
+          const oldPublicId = extractPublicId(existing.qr_image_url);
+          if (oldPublicId) await deleteImage(oldPublicId);
+        }
+        const result = await uploadImage(req.file.buffer, { type: 'payment_method', mimetype: req.file.mimetype });
+        data.qr_image_url = result.secure_url;
+      } else if (req.body.qr_image_url !== undefined) {
+        data.qr_image_url = req.body.qr_image_url || null;
+      }
+
+      const method = await prisma.venue_payment_methods.update({
+        where: { id: req.params.methodId },
+        data
+      });
+      res.json(method);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  app.put('/api/venues/:id/payment-methods/reorder', isAuthenticated, async (req, res) => {
+    try {
+      const { order } = req.body; // Array of { id, sort_order }
+      for (const item of order) {
+        await prisma.venue_payment_methods.update({
+          where: { id: item.id },
+          data: { sort_order: item.sort_order }
+        });
+      }
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  app.delete('/api/venues/:id/payment-methods/:methodId', isAuthenticated, async (req, res) => {
+    try {
+      const method = await prisma.venue_payment_methods.findUnique({ where: { id: req.params.methodId } });
+      if (method?.qr_image_url) {
+        const publicId = extractPublicId(method.qr_image_url);
+        if (publicId) await deleteImage(publicId);
+      }
+      await prisma.venue_payment_methods.delete({ where: { id: req.params.methodId } });
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // Public payment methods (no auth)
+  app.get('/api/public/venues/:slug/payment-methods', async (req, res) => {
+    try {
+      const venue = await prisma.venues.findUnique({ where: { slug: req.params.slug } });
+      if (!venue || !venue.is_public) {
+        return res.status(404).json({ error: 'Venue not found' });
+      }
+      const methods = await prisma.venue_payment_methods.findMany({
+        where: { venue_id: venue.id, is_active: true },
+        orderBy: { sort_order: 'asc' },
+        select: { id: true, method_type: true, label: true, account_info: true, holder_name: true, qr_image_url: true, instructions: true }
+      });
+      res.json(methods);
     } catch (error) {
       res.status(500).json({ error: error.message });
     }
@@ -1710,7 +1889,47 @@ async function startServer() {
           where: { payment_id: paymentId }
         });
       }
-      
+
+      // Update linked estimate and notify client via WhatsApp
+      if (verified === true) {
+        const linkedEstimate = await prisma.estimates.findFirst({
+          where: { payment_id: paymentId }
+        });
+        if (linkedEstimate) {
+          await prisma.estimates.update({
+            where: { id: linkedEstimate.id },
+            data: { payment_status: 'verified', updated_at: new Date() }
+          });
+
+          // Notify client via WhatsApp
+          if (linkedEstimate.conversation_id) {
+            const conv = await prisma.chat_conversations.findUnique({
+              where: { id: linkedEstimate.conversation_id }
+            });
+            if (conv?.phone && conv?.venue_id && whatsappClient.isAvailable()) {
+              try {
+                const venueForNotif = await prisma.venues.findUnique({ where: { id: conv.venue_id } });
+                const confirmMsg = `✅ *¡Pago Verificado!*\n\n¡Hola ${conv.name || ''}! Tu pago ha sido verificado exitosamente. Tu reserva en *${venueForNotif?.name || 'la cabaña'}* está confirmada.\n\n¡Te esperamos! 🎉`;
+                await whatsappClient.sendMessage(conv.venue_id, conv.phone, confirmMsg);
+              } catch (notifErr) {
+                console.error('[payment-verify] Failed to notify client:', notifErr.message);
+              }
+            }
+          }
+        }
+      } else if (verified === false) {
+        // Reject linked estimate
+        const linkedEstimate = await prisma.estimates.findFirst({
+          where: { payment_id: paymentId }
+        });
+        if (linkedEstimate) {
+          await prisma.estimates.update({
+            where: { id: linkedEstimate.id },
+            data: { payment_status: 'rejected', updated_at: new Date() }
+          });
+        }
+      }
+
       res.json(payment);
     } catch (error) {
       res.status(500).json({ error: error.message });
@@ -4550,10 +4769,20 @@ Para la referencia, busca el numero de factura, tiquete, o comprobante (NO el CU
       const planMap = {};
       plans.forEach(p => { planMap[p.id] = p; });
       
+      // Resolve payment method labels
+      const paymentMethodIds = [...new Set(estimates.filter(e => e.payment_method_id).map(e => e.payment_method_id))];
+      const paymentMethods = paymentMethodIds.length > 0 ? await prisma.venue_payment_methods.findMany({
+        where: { id: { in: paymentMethodIds } },
+        select: { id: true, label: true }
+      }) : [];
+      const pmMap = {};
+      paymentMethods.forEach(pm => { pmMap[pm.id] = pm.label; });
+
       const enriched = estimates.map(e => ({
         ...e,
         venue: venueMap[e.venue_id] || null,
-        plan: e.plan_id ? (planMap[e.plan_id] || null) : null
+        plan: e.plan_id ? (planMap[e.plan_id] || null) : null,
+        payment_method_label: e.payment_method_id ? (pmMap[e.payment_method_id] || null) : null
       }));
       
       res.json(enriched);
@@ -4574,8 +4803,9 @@ Para la referencia, busca el numero de factura, tiquete, o comprobante (NO el CU
       
       const venue = await prisma.venues.findUnique({ where: { id: estimate.venue_id } });
       const plan = estimate.plan_id ? await prisma.venue_plans.findUnique({ where: { id: estimate.plan_id } }) : null;
-      
-      res.json({ ...estimate, venue, plan });
+      const paymentMethod = estimate.payment_method_id ? await prisma.venue_payment_methods.findUnique({ where: { id: estimate.payment_method_id } }) : null;
+
+      res.json({ ...estimate, venue, plan, payment_method_label: paymentMethod?.label || null });
     } catch (error) {
       res.status(500).json({ error: error.message });
     }
@@ -6414,7 +6644,7 @@ REGLAS:
   app.post('/api/chat/:venue_id', async (req, res) => {
     try {
       const { venue_id } = req.params;
-      const { message, conversation_id, provider_id, source = 'web', contact_type, contact_value } = req.body;
+      const { message, conversation_id, provider_id, source = 'web', contact_type, contact_value, media_url, media_type } = req.body;
 
       // Validate internal key for Baileys microservice callbacks
       if (source === 'baileys' && process.env.WHATSAPP_INTERNAL_KEY) {
@@ -6560,9 +6790,73 @@ REGLAS:
         data: {
           conversation_id: conversation.id,
           role: 'user',
-          content: userMessage
+          content: userMessage,
+          media_url: media_url || null,
+          media_type: media_type || null
         }
       });
+
+      // Auto-detect payment receipt: if image + estimate with payment_status 'qr_sent'
+      let receiptContext = null;
+      if (media_url && media_type === 'image') {
+        const pendingEstimate = await prisma.estimates.findFirst({
+          where: {
+            conversation_id: conversation.id,
+            payment_status: 'qr_sent'
+          },
+          orderBy: { created_at: 'desc' }
+        });
+        if (pendingEstimate) {
+          // Update estimate with receipt
+          await prisma.estimates.update({
+            where: { id: pendingEstimate.id },
+            data: {
+              payment_status: 'receipt_received',
+              receipt_url: media_url,
+              updated_at: new Date()
+            }
+          });
+
+          // Create payment record
+          const paymentMethodRecord = pendingEstimate.payment_method_id
+            ? await prisma.venue_payment_methods.findUnique({ where: { id: pendingEstimate.payment_method_id } })
+            : null;
+
+          const payment = await prisma.payments.create({
+            data: {
+              amount: pendingEstimate.agreed_price || pendingEstimate.calculated_price,
+              payment_method: paymentMethodRecord?.label || 'WhatsApp',
+              receipt_url: media_url,
+              verified: false,
+              created_by: 'chat_ai',
+              type: 'accommodation'
+            }
+          });
+
+          await prisma.estimates.update({
+            where: { id: pendingEstimate.id },
+            data: { payment_id: payment.id, updated_at: new Date() }
+          });
+
+          // Notify venue owner via system WhatsApp
+          const waConn = await prisma.whatsapp_connections.findUnique({ where: { venue_id } });
+          const notificationPhone = waConn?.notification_phone || (venue.whatsapp ? String(venue.whatsapp) : null);
+          if (notificationPhone && whatsappClient.isAvailable()) {
+            try {
+              const clientName = conversation.name || 'Cliente';
+              const clientPhone = conversation.phone || 'desconocido';
+              const amount = pendingEstimate.agreed_price || pendingEstimate.calculated_price || 'N/A';
+              const methodName = paymentMethodRecord?.label || 'N/A';
+              const notifMsg = `💰 *Comprobante de Pago Recibido - ${venue.name || 'Venue'}*\n\n*Cliente:* ${clientName}\n*Teléfono:* ${clientPhone}\n*Monto:* $${amount}\n*Método:* ${methodName}\n\n🔗 Verifica el pago en el sistema para confirmar la reserva.`;
+              await whatsappClient.sendSystemMessage(notificationPhone, notifMsg);
+            } catch (notifErr) {
+              console.error('[payment] Failed to send receipt notification:', notifErr.message);
+            }
+          }
+
+          receiptContext = '[El cliente envió un comprobante de pago. El sistema ya lo registró automáticamente. Confirma al cliente que recibiste su comprobante y que será verificado por el equipo pronto.]';
+        }
+      }
       
       // Build context and messages
       const context = llmService.buildVenueContext(venue, templates, plans);
@@ -6578,8 +6872,9 @@ REGLAS:
         llmMessages.push({ role: msg.role, content: msg.content });
       }
       
-      // Add current message
-      llmMessages.push({ role: 'user', content: userMessage });
+      // Add current message (with receipt context if applicable)
+      const finalUserMessage = receiptContext ? `${userMessage}\n\n${receiptContext}` : userMessage;
+      llmMessages.push({ role: 'user', content: finalUserMessage });
       
       // Call LLM using configured model with tools
       const chatLlmStart = Date.now();
@@ -6991,6 +7286,132 @@ REGLAS:
             
             llmResponse.tools_used = llmResponse.tools_used || [];
             llmResponse.tools_used.push('create_estimate');
+          } else if (toolCall.function.name === 'get_payment_methods') {
+            // Get active payment methods for this venue
+            const paymentMethods = await prisma.venue_payment_methods.findMany({
+              where: { venue_id, is_active: true },
+              orderBy: { sort_order: 'asc' },
+              select: { id: true, method_type: true, label: true, account_info: true, holder_name: true, instructions: true, qr_image_url: true }
+            });
+
+            const paymentResult = {
+              methods: paymentMethods.map(m => ({
+                id: m.id,
+                type: m.method_type,
+                name: m.label,
+                account_info: m.account_info,
+                holder_name: m.holder_name,
+                has_qr: !!m.qr_image_url,
+                instructions: m.instructions
+              })),
+              message: paymentMethods.length > 0
+                ? `Hay ${paymentMethods.length} método(s) de pago disponible(s).`
+                : 'No hay métodos de pago configurados. El cliente deberá coordinar el pago directamente con el venue.'
+            };
+
+            const toolResultContent = JSON.stringify(paymentResult);
+
+            if (chatModelConfig.provider === 'anthropic') {
+              llmMessages.push({
+                role: 'assistant',
+                content: [{ type: 'tool_use', id: toolCall.id, name: toolCall.function.name, input: {} }]
+              });
+              llmMessages.push({
+                role: 'user',
+                content: [{ type: 'tool_result', tool_use_id: toolCall.id, content: toolResultContent }]
+              });
+            } else {
+              llmMessages.push({ role: 'assistant', content: null, tool_calls: llmResponse.tool_calls });
+              llmMessages.push({ role: 'tool', tool_call_id: toolCall.id, content: toolResultContent });
+            }
+
+            llmResponse = await llmService.callLLMByCode(chatProviderCode, llmMessages, {
+              maxTokens: 1024,
+              temperature: 0.7,
+              tools: llmService.CHAT_TOOLS
+            });
+
+            llmResponse.tools_used = llmResponse.tools_used || [];
+            llmResponse.tools_used.push('get_payment_methods');
+          } else if (toolCall.function.name === 'send_payment_info') {
+            const args = JSON.parse(toolCall.function.arguments);
+
+            // Fetch the payment method
+            const paymentMethod = args.payment_method_id
+              ? await prisma.venue_payment_methods.findUnique({ where: { id: args.payment_method_id } })
+              : null;
+
+            let sendResult;
+            if (!paymentMethod) {
+              sendResult = { success: false, message: 'Método de pago no encontrado.' };
+            } else {
+              // Update estimate
+              if (args.estimate_id) {
+                await prisma.estimates.update({
+                  where: { id: args.estimate_id },
+                  data: {
+                    payment_status: 'qr_sent',
+                    payment_method_id: paymentMethod.id,
+                    updated_at: new Date()
+                  }
+                });
+              }
+
+              // Build caption
+              const amount = args.payment_amount || 0;
+              let caption = `💳 *Pago - ${paymentMethod.label}*\n`;
+              if (amount) caption += `\n💰 *Monto:* $${Number(amount).toLocaleString('es-CO')}\n`;
+              if (paymentMethod.account_info) caption += `\n📱 *Cuenta/Número:* ${paymentMethod.account_info}`;
+              if (paymentMethod.holder_name) caption += `\n👤 *Titular:* ${paymentMethod.holder_name}`;
+              if (paymentMethod.instructions) caption += `\n\n📝 ${paymentMethod.instructions}`;
+              caption += '\n\n📸 Una vez realices el pago, envía la foto del comprobante por este chat.';
+
+              // Send QR image or text via WhatsApp if source is baileys
+              if (source === 'baileys' && conversation.phone && whatsappClient.isAvailable()) {
+                try {
+                  if (paymentMethod.qr_image_url) {
+                    await whatsappClient.sendImage(venue_id, conversation.phone, paymentMethod.qr_image_url, caption);
+                  } else {
+                    await whatsappClient.sendMessage(venue_id, conversation.phone, caption);
+                  }
+                } catch (sendErr) {
+                  console.error('[payment] Failed to send payment info via WhatsApp:', sendErr.message);
+                }
+              }
+
+              sendResult = {
+                success: true,
+                method_name: paymentMethod.label,
+                has_qr: !!paymentMethod.qr_image_url,
+                message: paymentMethod.qr_image_url
+                  ? `Se envió el QR de ${paymentMethod.label} al cliente con los datos de pago.`
+                  : `Se enviaron los datos de pago de ${paymentMethod.label} al cliente.`
+              };
+            }
+
+            const toolResultContent = JSON.stringify(sendResult);
+
+            if (chatModelConfig.provider === 'anthropic') {
+              llmMessages.push({
+                role: 'assistant',
+                content: [{ type: 'tool_use', id: toolCall.id, name: toolCall.function.name, input: args }]
+              });
+              llmMessages.push({
+                role: 'user',
+                content: [{ type: 'tool_result', tool_use_id: toolCall.id, content: toolResultContent }]
+              });
+            } else {
+              llmMessages.push({ role: 'assistant', content: null, tool_calls: llmResponse.tool_calls });
+              llmMessages.push({ role: 'tool', tool_call_id: toolCall.id, content: toolResultContent });
+            }
+
+            llmResponse = await llmService.callLLMByCode(chatProviderCode, llmMessages, {
+              maxTokens: 1024,
+              temperature: 0.7
+            });
+
+            llmResponse.tools_used = llmResponse.tools_used || [];
+            llmResponse.tools_used.push('send_payment_info');
           } else if (toolCall.function.name === 'escalate_to_human') {
             const args = JSON.parse(toolCall.function.arguments);
 

--- a/server/llm-service.js
+++ b/server/llm-service.js
@@ -330,6 +330,8 @@ HERRAMIENTAS DISPONIBLES:
 - "get_plans": Para consultar planes disponibles con precios y lo que incluyen
 - "check_availability": Para verificar disponibilidad en fechas específicas
 - "create_estimate": Para crear una cotización cuando el cliente quiera reservar
+- "get_payment_methods": Para obtener los métodos de pago disponibles del venue
+- "send_payment_info": Para enviar al cliente los datos de pago del método elegido (QR, número de cuenta, etc.)
 - "escalate_to_human": Para escalar la conversación a un humano real
 
 FLUJO DE CONVERSACIÓN:
@@ -372,6 +374,15 @@ CONFIRMACIÓN DE RESERVA:
   5. Número de niños (puede ser 0)
 - Si falta información, pregunta específicamente por lo que falta.
 - Una vez creada la cotización, confirma los detalles al cliente.
+
+FLUJO DE PAGO (después de crear cotización):
+1. Una vez creada la cotización, usa "get_payment_methods" para obtener los métodos de pago disponibles
+2. Presenta las opciones al cliente de forma clara (ej: "Puedes pagar por Nequi, Daviplata o Bancolombia")
+3. Cuando el cliente elija un método, usa "send_payment_info" con el estimate_id y el payment_method_id elegido
+4. El sistema enviará automáticamente el QR o datos de la cuenta al cliente
+5. Cuando el cliente envíe una imagen (comprobante), el sistema la procesará automáticamente
+6. NO confirmes el pago tú mismo — solo el venue puede verificar pagos
+7. Informa al cliente que su comprobante fue recibido y será verificado pronto
 
 ESCALAMIENTO A HUMANO:
 - Si el cliente pide hablar con un humano, una persona real, un encargado, el dueño, o similar → usa escalate_to_human con reason "client_requested"
@@ -538,6 +549,43 @@ const CHAT_TOOLS = [
           }
         },
         required: ['customer_name', 'plan_name', 'check_in', 'adults']
+      }
+    }
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_payment_methods',
+      description: 'Obtiene los métodos de pago disponibles del venue (Nequi, Daviplata, Bancolombia, etc.). Usar después de crear una cotización para ofrecer al cliente las opciones de pago.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: []
+      }
+    }
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'send_payment_info',
+      description: 'Envía al cliente la información de pago del método elegido (datos de cuenta, QR si existe). Usar cuando el cliente ya eligió un método de pago. Actualiza la cotización con el estado de pago.',
+      parameters: {
+        type: 'object',
+        properties: {
+          estimate_id: {
+            type: 'string',
+            description: 'ID de la cotización/estimate'
+          },
+          payment_method_id: {
+            type: 'string',
+            description: 'ID del método de pago elegido por el cliente'
+          },
+          payment_amount: {
+            type: 'number',
+            description: 'Monto a pagar'
+          }
+        },
+        required: ['estimate_id', 'payment_method_id']
       }
     }
   },

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -249,7 +249,9 @@ model venues {
   brand_color_primary           String?   @db.VarChar(7)
   brand_color_secondary         String?   @db.VarChar(7)
   logo_url                      String?
+  commission_percentage Decimal?  @db.Decimal(5, 2)
   venue_plans          venue_plans[]
+  payment_methods      venue_payment_methods[]
 }
 
 model sessions {
@@ -507,6 +509,8 @@ model chat_messages {
   model           String?            @db.VarChar(100)
   tokens_used     Int?
   cost            Decimal?           @db.Decimal
+  media_url       String?
+  media_type      String?            @db.VarChar(30)
   created_at      DateTime           @default(now()) @db.Timestamptz(6)
   conversation    chat_conversations @relation(fields: [conversation_id], references: [id], onDelete: Cascade)
 }
@@ -525,14 +529,18 @@ model estimates {
   calculated_price Decimal?  @db.Decimal
   notes            String?
   status           String    @default("pending") @db.VarChar(50)
-  conversation_id  String?   @db.Uuid
-  created_by       String?   @db.VarChar(255)
-  created_at       DateTime  @default(now()) @db.Timestamptz(6)
-  updated_at       DateTime? @db.Timestamptz(6)
-  converted_at     DateTime? @db.Timestamptz(6)
-  accommodation_id String?   @db.Uuid
-  agreed_price     Decimal?  @db.Decimal
-  discount_note    String?
+  conversation_id   String?   @db.Uuid
+  created_by        String?   @db.VarChar(255)
+  created_at        DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at        DateTime? @db.Timestamptz(6)
+  converted_at      DateTime? @db.Timestamptz(6)
+  accommodation_id  String?   @db.Uuid
+  agreed_price      Decimal?  @db.Decimal
+  discount_note     String?
+  payment_status    String?   @default("none") @db.VarChar(30)
+  payment_id        String?   @db.Uuid
+  receipt_url       String?
+  payment_method_id String?   @db.Uuid
 }
 
 model inventory_categories {
@@ -722,6 +730,26 @@ model pending_task_images {
   sort_order      Int           @default(0)
   created_at      DateTime      @default(now()) @db.Timestamptz(6)
   pending_task    pending_tasks @relation(fields: [pending_task_id], references: [id], onDelete: Cascade)
+}
+
+// ========================================
+// VENUE PAYMENT METHODS
+// ========================================
+
+model venue_payment_methods {
+  id           String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  venue_id     String    @db.Uuid
+  method_type  String    @db.VarChar(50)
+  label        String    @db.VarChar(100)
+  account_info String?   @db.VarChar(255)
+  holder_name  String?   @db.VarChar(255)
+  qr_image_url String?
+  instructions String?
+  is_active    Boolean   @default(true)
+  sort_order   Int       @default(0)
+  created_at   DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at   DateTime? @db.Timestamptz(6)
+  venue        venues    @relation(fields: [venue_id], references: [id], onDelete: Cascade)
 }
 
 // ========================================

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -511,6 +511,9 @@ model chat_messages {
   cost            Decimal?           @db.Decimal
   media_url       String?
   media_type      String?            @db.VarChar(30)
+  status          String?            @db.VarChar(20)
+  error_details   String?
+  external_id     String?            @db.VarChar(255)
   created_at      DateTime           @default(now()) @db.Timestamptz(6)
   conversation    chat_conversations @relation(fields: [conversation_id], references: [id], onDelete: Cascade)
 }
@@ -999,4 +1002,22 @@ model auth_verification_codes {
   @@index([email, status])
   @@index([code, status])
   @@index([expires_at])
+}
+
+// ========================================
+// WHATSAPP EVENT LOG
+// ========================================
+
+model whatsapp_event_log {
+  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  venue_id   String?  @db.Uuid
+  event_type String   @db.VarChar(50)
+  details    String?
+  phone      String?  @db.VarChar(50)
+  message_id String?  @db.Uuid
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+
+  @@index([venue_id])
+  @@index([event_type])
+  @@index([created_at])
 }

--- a/server/services/whatsappClient.js
+++ b/server/services/whatsappClient.js
@@ -35,6 +35,7 @@ module.exports = {
   disconnectVenue: (venueId) => callService('POST', `/api/venues/${venueId}/disconnect`),
   getStatus: (venueId) => callService('GET', `/api/venues/${venueId}/status`),
   sendMessage: (venueId, phone, text) => callService('POST', '/api/send/venue', { venueId, phone, text }),
+  sendImage: (venueId, phone, imageUrl, caption) => callService('POST', '/api/send/venue/image', { venueId, phone, imageUrl, caption }),
 
   // System connection
   connectSystem: () => callService('POST', '/api/system/connect'),

--- a/server/upload-service.js
+++ b/server/upload-service.js
@@ -3,7 +3,7 @@ const cloudinary = require('./cloudinary');
 
 const FOLDER_PREFIX = process.env.CLOUDINARY_FOLDER_PREFIX || 'cabanero-dev';
 
-const ALLOWED_TYPES = ['receipt', 'venue', 'plan', 'deposit', 'inventory', 'maintenance'];
+const ALLOWED_TYPES = ['receipt', 'venue', 'plan', 'deposit', 'inventory', 'maintenance', 'chat_media', 'payment_method'];
 
 async function uploadImage(fileBuffer, { type, mimetype }) {
   if (!ALLOWED_TYPES.includes(type)) {

--- a/src/components/venues/VenueForm.vue
+++ b/src/components/venues/VenueForm.vue
@@ -246,6 +246,19 @@
       </div>
     </div>
     <div class="mb-3">
+      <CFormLabel for="commissionPercentage">Comisión del Venue (%)</CFormLabel>
+      <CFormInput
+        id="commissionPercentage"
+        v-model="form.commission_percentage"
+        type="number"
+        step="0.01"
+        min="0"
+        max="100"
+        placeholder="Ej: 10.00"
+      />
+      <div class="form-text">Porcentaje de comisión que cobra la plataforma sobre reservas.</div>
+    </div>
+    <div class="mb-3">
       <CFormCheck
         id="venueIsPublic"
         v-model="form.is_public"

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -515,6 +515,13 @@ const routes = [
         meta: { breadcrumb: 'WhatsApp - CabanIA' },
       },
       {
+        path: '/business/venues/:id/payment-methods',
+        name: 'VenuePaymentMethods',
+        component: () => import('@/views/venues/VenuePaymentMethodsView.vue'),
+        props: true,
+        meta: { breadcrumb: 'Metodos de Pago' },
+      },
+      {
         path: '/business/venues/:id/plans',
         name: 'VenuePlans',
         component: () => import('@/views/venues/VenuePlansView.vue'),

--- a/src/views/estimates/EstimateDetailView.vue
+++ b/src/views/estimates/EstimateDetailView.vue
@@ -71,6 +71,42 @@
               </CCol>
             </CRow>
 
+            <div v-if="estimate.payment_status && estimate.payment_status !== 'none'" class="mb-3">
+              <CRow>
+                <CCol :md="6">
+                  <div class="p-3 border rounded">
+                    <h6 class="text-muted mb-2">Estado de Pago</h6>
+                    <CBadge :color="getPaymentStatusColor(estimate.payment_status)" class="fs-6">
+                      {{ getPaymentStatusLabel(estimate.payment_status) }}
+                    </CBadge>
+                    <p v-if="estimate.payment_method_label" class="mt-2 mb-0">
+                      <strong>Método:</strong> <span class="text-body-secondary">{{ estimate.payment_method_label }}</span>
+                    </p>
+                  </div>
+                </CCol>
+                <CCol :md="6" v-if="estimate.receipt_url">
+                  <div class="p-3 border rounded">
+                    <h6 class="text-muted mb-2">Comprobante</h6>
+                    <img
+                      :src="estimate.receipt_url"
+                      class="img-thumbnail"
+                      style="max-width: 200px; cursor: pointer;"
+                      alt="Comprobante"
+                      @click="receiptModalVisible = true"
+                    />
+                    <div class="mt-2" v-if="estimate.payment_status === 'receipt_received' && estimate.payment_id">
+                      <CButton color="success" size="sm" @click="verifyPayment(true)">
+                        <CIcon :icon="cilCheckCircle" class="me-1" /> Verificar Pago
+                      </CButton>
+                      <CButton color="danger" size="sm" variant="outline" class="ms-2" @click="verifyPayment(false)">
+                        Rechazar
+                      </CButton>
+                    </div>
+                  </div>
+                </CCol>
+              </CRow>
+            </div>
+
             <div v-if="estimate.notes" class="mb-3">
               <p><strong>Notas:</strong></p>
               <p class="text-body-secondary" style="white-space: pre-wrap;">{{ estimate.notes }}</p>
@@ -115,6 +151,12 @@
     </CCol>
   </CRow>
 
+  <CModal :visible="receiptModalVisible" @close="receiptModalVisible = false" size="lg" alignment="center">
+    <CModalBody class="text-center p-0">
+      <img v-if="estimate?.receipt_url" :src="estimate.receipt_url" class="img-fluid" alt="Comprobante completo" />
+    </CModalBody>
+  </CModal>
+
   <CToaster placement="top-end">
     <CToast v-if="toast.visible" :color="toast.color" class="text-white" :autohide="true" :delay="3000" @close="toast.visible = false">
       <CToastBody>{{ toast.message }}</CToastBody>
@@ -126,6 +168,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { CIcon } from '@coreui/icons-vue'
+import { CModal, CModalBody } from '@coreui/vue'
 import { cilPencil, cilCheckCircle, cilPhone, cilUser } from '@coreui/icons'
 import { getEstimateById, convertEstimate } from '@/services/estimateService'
 import { useBreadcrumbStore } from '@/stores/breadcrumb.js'
@@ -134,6 +177,7 @@ const route = useRoute()
 const router = useRouter()
 const breadcrumbStore = useBreadcrumbStore()
 const estimate = ref(null)
+const receiptModalVisible = ref(false)
 
 const toast = ref({
   visible: false,
@@ -186,6 +230,50 @@ const getStatusColor = (status) => {
     case 'converted': return 'success'
     case 'cancelled': return 'danger'
     default: return 'secondary'
+  }
+}
+
+const getPaymentStatusColor = (status) => {
+  switch (status) {
+    case 'qr_sent': return 'info'
+    case 'receipt_received': return 'warning'
+    case 'verified': return 'success'
+    case 'rejected': return 'danger'
+    default: return 'secondary'
+  }
+}
+
+const getPaymentStatusLabel = (status) => {
+  switch (status) {
+    case 'none': return 'Sin pago'
+    case 'qr_sent': return 'QR Enviado'
+    case 'receipt_received': return 'Comprobante Recibido'
+    case 'verified': return 'Pago Verificado'
+    case 'rejected': return 'Pago Rechazado'
+    default: return status
+  }
+}
+
+const verifyPayment = async (verified) => {
+  if (!estimate.value?.payment_id) return
+  const action = verified ? 'verificar' : 'rechazar'
+  if (!confirm(`¿Estás seguro de ${action} este pago?`)) return
+  try {
+    const response = await fetch(`/api/payments/${estimate.value.payment_id}/verify`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ verified })
+    })
+    if (response.ok) {
+      showToast(verified ? 'Pago verificado exitosamente' : 'Pago rechazado', verified ? 'success' : 'warning')
+      loadEstimate()
+    } else {
+      const data = await response.json()
+      showToast(data.error || 'Error al procesar', 'danger')
+    }
+  } catch (error) {
+    showToast('Error al procesar pago', 'danger')
   }
 }
 

--- a/src/views/estimates/EstimatesListView.vue
+++ b/src/views/estimates/EstimatesListView.vue
@@ -92,6 +92,13 @@
                   <CBadge :color="getStatusColor(estimate.status)">
                     {{ getStatusLabel(estimate.status) }}
                   </CBadge>
+                  <CBadge
+                    v-if="estimate.payment_status && estimate.payment_status !== 'none'"
+                    :color="getPaymentStatusColor(estimate.payment_status)"
+                    class="ms-1"
+                  >
+                    {{ getPaymentStatusLabel(estimate.payment_status) }}
+                  </CBadge>
                 </CTableDataCell>
                 <CTableDataCell>
                   <CButton
@@ -342,6 +349,26 @@ const getStatusLabel = (status) => {
     case 'confirmed': return 'Confirmada'
     case 'converted': return 'Convertida'
     case 'cancelled': return 'Cancelada'
+    default: return status
+  }
+}
+
+const getPaymentStatusColor = (status) => {
+  switch (status) {
+    case 'qr_sent': return 'info'
+    case 'receipt_received': return 'warning'
+    case 'verified': return 'success'
+    case 'rejected': return 'danger'
+    default: return 'secondary'
+  }
+}
+
+const getPaymentStatusLabel = (status) => {
+  switch (status) {
+    case 'qr_sent': return 'QR Enviado'
+    case 'receipt_received': return 'Comprobante'
+    case 'verified': return 'Pagado'
+    case 'rejected': return 'Rechazado'
     default: return status
   }
 }

--- a/src/views/public/PublicVenueView.vue
+++ b/src/views/public/PublicVenueView.vue
@@ -150,6 +150,39 @@
       </div>
     </section>
 
+    <!-- Payment Methods Section -->
+    <section class="payment-methods-section container-narrow" v-if="paymentMethods.length > 0">
+      <h2 class="section-title">Metodos de Pago</h2>
+      <div class="payment-methods-grid">
+        <div v-for="pm in paymentMethods" :key="pm.id" class="pm-card">
+          <div class="pm-icon">
+            {{ getPaymentIcon(pm.method_type) }}
+          </div>
+          <div class="pm-info">
+            <div class="pm-name">{{ pm.label }}</div>
+            <div v-if="pm.account_info" class="pm-account">{{ pm.account_info }}</div>
+            <div v-if="pm.holder_name" class="pm-holder">{{ pm.holder_name }}</div>
+          </div>
+          <div v-if="pm.qr_image_url" class="pm-qr">
+            <img
+              :src="pm.qr_image_url"
+              alt="QR"
+              class="pm-qr-img"
+              @click="pmPreview = pm.qr_image_url"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- QR Preview Modal -->
+    <div v-if="pmPreview" class="pm-modal-overlay" @click="pmPreview = null">
+      <div class="pm-modal-content" @click.stop>
+        <img :src="pmPreview" alt="QR" class="img-fluid" />
+        <button class="pm-modal-close" @click="pmPreview = null">&times;</button>
+      </div>
+    </div>
+
     <!-- Booking Panel Widget -->
     <BookingPanelWidget
       v-if="venue.id"
@@ -183,6 +216,8 @@ const venue = ref({})
 const images = ref([])
 const amenities = ref([])
 const plans = ref([])
+const paymentMethods = ref([])
+const pmPreview = ref(null)
 const activeImageIdx = ref(0)
 
 // Provide venue brand colors to parent layout (for orbs)
@@ -272,6 +307,7 @@ const loadVenue = async () => {
     images.value = data.images || []
     amenities.value = data.amenities || []
     plans.value = data.plans || []
+    paymentMethods.value = data.paymentMethods || []
 
     // Set cover image as default
     const coverIdx = images.value.findIndex(i => i.is_cover)
@@ -284,6 +320,15 @@ const loadVenue = async () => {
   } finally {
     loading.value = false
   }
+}
+
+const getPaymentIcon = (type) => {
+  const icons = {
+    nequi: '📱', daviplata: '📱', bancolombia: '🏦', davivienda: '🏦',
+    breb: '📲', pse: '💻', credit_card_national: '💳', credit_card_international: '💳',
+    cash: '💵', custom: '💰'
+  }
+  return icons[type] || '💰'
 }
 
 const planTypeLabel = (type) => {
@@ -670,6 +715,85 @@ onMounted(async () => {
   transform: translateY(-2px);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
   color: #fff;
+}
+
+/* Payment Methods */
+.payment-methods-section {
+  margin-bottom: 2rem;
+}
+.payment-methods-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+.pm-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: rgba(255,255,255,0.08);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 12px;
+}
+.pm-icon {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+.pm-info {
+  flex-grow: 1;
+  min-width: 0;
+}
+.pm-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+.pm-account, .pm-holder {
+  font-size: 0.82rem;
+  opacity: 0.75;
+}
+.pm-qr-img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+.pm-qr-img:hover {
+  transform: scale(1.1);
+}
+.pm-modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.8);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pm-modal-content {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+}
+.pm-modal-content img {
+  max-width: 100%;
+  max-height: 85vh;
+  border-radius: 8px;
+}
+.pm-modal-close {
+  position: absolute;
+  top: -12px; right: -12px;
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: #fff;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Plans */

--- a/src/views/venues/VenueChatView.vue
+++ b/src/views/venues/VenueChatView.vue
@@ -54,6 +54,14 @@
                 :class="['message-wrapper', message.role === 'user' ? 'message-user' : 'message-assistant']"
               >
                 <div :class="['message-bubble', message.role === 'user' ? 'bubble-user' : 'bubble-assistant']">
+                  <div v-if="message.media_url" class="message-media mb-2">
+                    <img
+                      :src="message.media_url"
+                      class="chat-image"
+                      alt="Imagen"
+                      @click="openImageModal(message.media_url)"
+                    />
+                  </div>
                   <div class="message-content">{{ message.content }}</div>
                   <div v-if="isDev && message.role === 'assistant' && message.meta" class="message-meta">
                     <small class="text-muted">
@@ -172,6 +180,12 @@
       <CToastBody>{{ toast.message }}</CToastBody>
     </CToast>
   </CToaster>
+
+  <CModal :visible="!!imageModalUrl" @close="imageModalUrl = null" size="lg" alignment="center">
+    <CModalBody class="text-center p-0">
+      <img v-if="imageModalUrl" :src="imageModalUrl" class="img-fluid" alt="Imagen completa" />
+    </CModalBody>
+  </CModal>
 </template>
 
 <script setup>
@@ -182,7 +196,7 @@ import {
   CFormSelect, CFormInput, CInputGroup,
   CToaster, CToast, CToastBody,
   CTable, CTableHead, CTableBody, CTableRow, CTableHeaderCell, CTableDataCell,
-  CBadge
+  CBadge, CModal, CModalBody
 } from '@coreui/vue'
 import { CIcon } from '@coreui/icons-vue'
 import { getVenueById } from '@/services/venueService'
@@ -208,6 +222,7 @@ const loadingConversations = ref(false)
 const estimateId = ref(null)
 const arrivedWithConversation = ref(false)
 const resumingConvId = ref(null)
+const imageModalUrl = ref(null)
 const activeConvSource = ref(null) // source of the active conversation (baileys, web, etc.)
 const activeConvPhone = ref(null)
 const activeConvName = ref(null)
@@ -355,6 +370,7 @@ const resumeConversation = async (conv) => {
       messages.value = data.messages.map(m => ({
         role: m.role,
         content: (m.content || '').replace(/\n?<!-- \{.*?\} -->/g, ''),
+        media_url: m.media_url || null,
         meta: m.role === 'assistant' ? { model: m.model, tokens: m.tokens_used } : undefined
       }))
     }
@@ -399,6 +415,10 @@ const SOURCE_ALIASES = { baileys: 'Ave', twilio: 'Twilio', web: 'Web', whatsapp:
 
 const getSourceLabel = (source) => SOURCE_ALIASES[source] || source
 
+const openImageModal = (url) => {
+  imageModalUrl.value = url
+}
+
 const getSourceColor = (source) => {
   const colors = { web: 'primary', whatsapp: 'success', baileys: 'success', twilio: 'info', meta: 'dark' }
   return colors[source] || 'secondary'
@@ -422,6 +442,7 @@ const pollConversations = async () => {
         const newMessages = data.messages.map(m => ({
           role: m.role,
           content: (m.content || '').replace(/\n?<!-- \{.*?\} -->/g, ''),
+          media_url: m.media_url || null,
           meta: m.role === 'assistant' ? { model: m.model, tokens: m.tokens_used } : undefined
         }))
         // Only update if message count changed (avoid flicker)
@@ -523,5 +544,17 @@ onUnmounted(() => {
   margin-top: 0.5rem;
   padding-top: 0.5rem;
   border-top: 1px solid rgba(0,0,0,0.1);
+}
+
+.chat-image {
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  object-fit: cover;
+  transition: opacity 0.2s;
+}
+.chat-image:hover {
+  opacity: 0.85;
 }
 </style>

--- a/src/views/venues/VenueChatView.vue
+++ b/src/views/venues/VenueChatView.vue
@@ -63,9 +63,19 @@
                     />
                   </div>
                   <div class="message-content">{{ message.content }}</div>
+                  <div class="message-footer">
+                    <small v-if="message.created_at" class="message-time">{{ formatTime(message.created_at) }}</small>
+                    <span v-if="message.role === 'assistant' && message.status" class="message-status ms-1" :title="message.status === 'failed' ? (message.error_details || 'Error de envío') : message.status">
+                      <span v-if="message.status === 'pending'" class="text-muted">&#9203;</span>
+                      <span v-else-if="message.status === 'sent'" class="text-muted">&#10003;</span>
+                      <span v-else-if="message.status === 'delivered'" class="text-muted">&#10003;&#10003;</span>
+                      <span v-else-if="message.status === 'read'" class="status-read">&#10003;&#10003;</span>
+                      <span v-else-if="message.status === 'failed'" class="text-danger">&#10007;</span>
+                    </span>
+                  </div>
                   <div v-if="isDev && message.role === 'assistant' && message.meta" class="message-meta">
                     <small class="text-muted">
-                      {{ message.meta.model }} 
+                      {{ message.meta.model }}
                       <span v-if="message.meta.tokens">| {{ message.meta.tokens }} tokens</span>
                     </small>
                   </div>
@@ -371,6 +381,9 @@ const resumeConversation = async (conv) => {
         role: m.role,
         content: (m.content || '').replace(/\n?<!-- \{.*?\} -->/g, ''),
         media_url: m.media_url || null,
+        created_at: m.created_at || null,
+        status: m.status || null,
+        error_details: m.error_details || null,
         meta: m.role === 'assistant' ? { model: m.model, tokens: m.tokens_used } : undefined
       }))
     }
@@ -410,6 +423,13 @@ const formatDate = (dateStr) => {
   })
 }
 
+const formatTime = (dateStr) => {
+  if (!dateStr) return ''
+  return new Date(dateStr).toLocaleString('es-CO', {
+    hour: '2-digit', minute: '2-digit'
+  })
+}
+
 // Alias para nombres de servicios (cambiar aquí si se quiere renombrar)
 const SOURCE_ALIASES = { baileys: 'Ave', twilio: 'Twilio', web: 'Web', whatsapp: 'WhatsApp', meta: 'Meta' }
 
@@ -443,6 +463,9 @@ const pollConversations = async () => {
           role: m.role,
           content: (m.content || '').replace(/\n?<!-- \{.*?\} -->/g, ''),
           media_url: m.media_url || null,
+          created_at: m.created_at || null,
+          status: m.status || null,
+          error_details: m.error_details || null,
           meta: m.role === 'assistant' ? { model: m.model, tokens: m.tokens_used } : undefined
         }))
         // Only update if message count changed (avoid flicker)
@@ -556,5 +579,38 @@ onUnmounted(() => {
 }
 .chat-image:hover {
   opacity: 0.85;
+}
+
+.message-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: 0.25rem;
+  gap: 0.15rem;
+}
+
+.message-time {
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+.bubble-user .message-time {
+  color: rgba(255,255,255,0.7);
+}
+
+.message-status {
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.status-read {
+  color: #53bdeb;
+}
+
+.bubble-user .message-status {
+  color: rgba(255,255,255,0.7);
+}
+.bubble-user .status-read {
+  color: #a0d8ef;
 }
 </style>

--- a/src/views/venues/VenueDetail.vue
+++ b/src/views/venues/VenueDetail.vue
@@ -20,6 +20,9 @@
             <RouterLink :to="{ path: '/next', query: { venues: venue.id } }">
               <CButton color="info" size="sm">Próximos</CButton>
             </RouterLink>
+            <RouterLink :to="`/business/venues/${venue.id}/payment-methods`">
+              <CButton color="info" size="sm" variant="outline">Métodos de Pago</CButton>
+            </RouterLink>
             <RouterLink :to="`/business/venues/${venue.id}/whatsapp`">
               <CButton color="success" size="sm" variant="outline">WhatsApp</CButton>
             </RouterLink>

--- a/src/views/venues/VenuePaymentMethodsView.vue
+++ b/src/views/venues/VenuePaymentMethodsView.vue
@@ -1,0 +1,328 @@
+<template>
+  <CRow>
+    <CCol :xs="12" :lg="10" :xl="8" class="mx-auto">
+      <CCard class="mb-4">
+        <CCardHeader class="d-flex justify-content-between align-items-center">
+          <div>
+            <strong>Metodos de Pago</strong>
+            <span v-if="venue" class="text-muted ms-2">- {{ venue.name }}</span>
+          </div>
+          <div class="d-flex gap-2">
+            <CButton color="success" size="sm" @click="openForm()">+ Agregar Metodo</CButton>
+            <RouterLink :to="`/business/venues/${$route.params.id}`">
+              <CButton color="secondary" size="sm" variant="outline">Volver</CButton>
+            </RouterLink>
+          </div>
+        </CCardHeader>
+        <CCardBody>
+          <CSpinner v-if="loading" color="primary" />
+          <div v-else-if="methods.length === 0" class="text-center text-muted py-4">
+            No hay metodos de pago configurados. Agrega uno para que tus clientes puedan pagar por WhatsApp.
+          </div>
+          <div v-else>
+            <div
+              v-for="(method, index) in methods"
+              :key="method.id"
+              class="payment-method-card"
+              :class="{ 'opacity-50': !method.is_active }"
+            >
+              <div class="d-flex align-items-center gap-3">
+                <div class="drag-handle text-muted" style="cursor: grab;">
+                  <CIcon icon="cil-menu" />
+                </div>
+                <div v-if="method.qr_image_url" class="qr-thumb">
+                  <img
+                    :src="method.qr_image_url"
+                    alt="QR"
+                    class="img-thumbnail"
+                    style="width: 50px; height: 50px; object-fit: cover; cursor: pointer;"
+                    @click="previewImage = method.qr_image_url"
+                  />
+                </div>
+                <div class="flex-grow-1">
+                  <div class="fw-semibold">
+                    {{ method.label }}
+                    <CBadge :color="method.is_active ? 'success' : 'secondary'" class="ms-1" size="sm">
+                      {{ method.is_active ? 'Activo' : 'Inactivo' }}
+                    </CBadge>
+                  </div>
+                  <small class="text-muted">
+                    {{ getTypeLabel(method.method_type) }}
+                    <span v-if="method.account_info"> | {{ method.account_info }}</span>
+                    <span v-if="method.holder_name"> | {{ method.holder_name }}</span>
+                  </small>
+                </div>
+                <div class="d-flex gap-1">
+                  <CButton color="primary" size="sm" variant="ghost" @click="openForm(method)" title="Editar">
+                    <CIcon icon="cil-pencil" />
+                  </CButton>
+                  <CButton color="danger" size="sm" variant="ghost" @click="deleteMethod(method)" title="Eliminar">
+                    <CIcon icon="cil-trash" />
+                  </CButton>
+                </div>
+              </div>
+              <div v-if="method.instructions" class="mt-1 small text-muted ps-5">
+                {{ method.instructions }}
+              </div>
+            </div>
+          </div>
+        </CCardBody>
+      </CCard>
+    </CCol>
+  </CRow>
+
+  <!-- Form Modal -->
+  <CModal :visible="showForm" @close="showForm = false" size="lg">
+    <CModalHeader>
+      <CModalTitle>{{ editingMethod ? 'Editar' : 'Agregar' }} Metodo de Pago</CModalTitle>
+    </CModalHeader>
+    <CModalBody>
+      <CForm @submit.prevent="saveMethod">
+        <div class="mb-3">
+          <CFormLabel>Tipo</CFormLabel>
+          <CFormSelect v-model="form.method_type">
+            <option value="">Selecciona un tipo...</option>
+            <option v-for="cat in catalog" :key="cat.type" :value="cat.type">
+              {{ cat.label }}
+            </option>
+          </CFormSelect>
+        </div>
+        <div class="mb-3">
+          <CFormLabel>Nombre Visible</CFormLabel>
+          <CFormInput v-model="form.label" placeholder="Ej: Nequi, Bancolombia Ahorros" required />
+        </div>
+        <div class="mb-3">
+          <CFormLabel>Numero / Cuenta / Llave</CFormLabel>
+          <CFormInput v-model="form.account_info" placeholder="Ej: 300-123-4567, @casabaluna" />
+        </div>
+        <div class="mb-3">
+          <CFormLabel>Titular de la Cuenta</CFormLabel>
+          <CFormInput v-model="form.holder_name" placeholder="Ej: Juan Perez" />
+        </div>
+        <div class="mb-3">
+          <CFormLabel>Instrucciones Adicionales</CFormLabel>
+          <CFormTextarea v-model="form.instructions" rows="2" placeholder="Instrucciones para el cliente al pagar..." />
+        </div>
+        <div class="mb-3">
+          <CFormLabel>Imagen QR</CFormLabel>
+          <CFormInput type="file" accept="image/*" @change="onFileChange" />
+          <div v-if="form.qr_image_url && !form.qr_file" class="mt-2">
+            <img :src="form.qr_image_url" class="img-thumbnail" style="max-width: 150px;" />
+            <CButton color="danger" size="sm" variant="ghost" class="ms-2" @click="form.qr_image_url = null">
+              Quitar
+            </CButton>
+          </div>
+          <div v-if="form.qr_file" class="mt-2 text-success small">
+            Nuevo archivo seleccionado: {{ form.qr_file.name }}
+          </div>
+        </div>
+        <CFormCheck
+          v-model="form.is_active"
+          label="Activo"
+          class="mb-3"
+        />
+      </CForm>
+    </CModalBody>
+    <CModalFooter>
+      <CButton color="secondary" variant="outline" @click="showForm = false">Cancelar</CButton>
+      <CButton color="primary" @click="saveMethod" :disabled="saving">
+        <CSpinner v-if="saving" size="sm" class="me-1" />
+        {{ editingMethod ? 'Actualizar' : 'Crear' }}
+      </CButton>
+    </CModalFooter>
+  </CModal>
+
+  <!-- Image Preview Modal -->
+  <CModal :visible="!!previewImage" @close="previewImage = null" size="lg" alignment="center">
+    <CModalBody class="text-center p-0">
+      <img v-if="previewImage" :src="previewImage" class="img-fluid" alt="QR" />
+    </CModalBody>
+  </CModal>
+
+  <CToaster placement="top-end">
+    <CToast v-if="toast.visible" :color="toast.color" class="text-white" :autohide="true" :delay="3000" @close="toast.visible = false">
+      <CToastBody>{{ toast.message }}</CToastBody>
+    </CToast>
+  </CToaster>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import {
+  CRow, CCol, CCard, CCardHeader, CCardBody, CButton, CSpinner, CBadge,
+  CModal, CModalHeader, CModalTitle, CModalBody, CModalFooter,
+  CForm, CFormLabel, CFormInput, CFormSelect, CFormTextarea, CFormCheck,
+  CToaster, CToast, CToastBody
+} from '@coreui/vue'
+import { CIcon } from '@coreui/icons-vue'
+import { getVenueById } from '@/services/venueService'
+import { useBreadcrumbStore } from '@/stores/breadcrumb.js'
+
+const route = useRoute()
+const breadcrumbStore = useBreadcrumbStore()
+const venueId = route.params.id
+
+const venue = ref(null)
+const methods = ref([])
+const catalog = ref([])
+const loading = ref(true)
+const saving = ref(false)
+const showForm = ref(false)
+const editingMethod = ref(null)
+const previewImage = ref(null)
+
+const form = ref({
+  method_type: '',
+  label: '',
+  account_info: '',
+  holder_name: '',
+  instructions: '',
+  qr_image_url: null,
+  qr_file: null,
+  is_active: true
+})
+
+const toast = ref({ visible: false, message: '', color: 'success' })
+const showToast = (message, color = 'success') => {
+  toast.value = { visible: true, message, color }
+}
+
+const getTypeLabel = (type) => {
+  const found = catalog.value.find(c => c.type === type)
+  return found?.label || type
+}
+
+const loadData = async () => {
+  loading.value = true
+  try {
+    const [v, m, c] = await Promise.all([
+      getVenueById(venueId),
+      fetch(`/api/venues/${venueId}/payment-methods`, { credentials: 'include' }).then(r => r.json()),
+      fetch(`/api/venues/${venueId}/payment-methods/catalog`, { credentials: 'include' }).then(r => r.json())
+    ])
+    venue.value = v
+    methods.value = m
+    catalog.value = c
+    if (v?.name) breadcrumbStore.setTitle(`Metodos de Pago - ${v.name}`)
+  } catch (error) {
+    console.error('Error loading data:', error)
+    showToast('Error al cargar datos', 'danger')
+  } finally {
+    loading.value = false
+  }
+}
+
+const openForm = (method = null) => {
+  editingMethod.value = method
+  if (method) {
+    form.value = {
+      method_type: method.method_type,
+      label: method.label,
+      account_info: method.account_info || '',
+      holder_name: method.holder_name || '',
+      instructions: method.instructions || '',
+      qr_image_url: method.qr_image_url || null,
+      qr_file: null,
+      is_active: method.is_active
+    }
+  } else {
+    form.value = {
+      method_type: '',
+      label: '',
+      account_info: '',
+      holder_name: '',
+      instructions: '',
+      qr_image_url: null,
+      qr_file: null,
+      is_active: true
+    }
+  }
+  showForm.value = true
+}
+
+const onFileChange = (e) => {
+  form.value.qr_file = e.target.files[0] || null
+}
+
+const saveMethod = async () => {
+  if (!form.value.method_type || !form.value.label) {
+    showToast('Tipo y nombre son requeridos', 'warning')
+    return
+  }
+  saving.value = true
+  try {
+    const formData = new FormData()
+    formData.append('method_type', form.value.method_type)
+    formData.append('label', form.value.label)
+    formData.append('account_info', form.value.account_info)
+    formData.append('holder_name', form.value.holder_name)
+    formData.append('instructions', form.value.instructions)
+    formData.append('is_active', form.value.is_active)
+    if (form.value.qr_file) {
+      formData.append('qr_image', form.value.qr_file)
+    } else if (form.value.qr_image_url) {
+      formData.append('qr_image_url', form.value.qr_image_url)
+    } else {
+      formData.append('qr_image_url', '')
+    }
+
+    const url = editingMethod.value
+      ? `/api/venues/${venueId}/payment-methods/${editingMethod.value.id}`
+      : `/api/venues/${venueId}/payment-methods`
+    const method = editingMethod.value ? 'PUT' : 'POST'
+
+    const response = await fetch(url, {
+      method,
+      credentials: 'include',
+      body: formData
+    })
+
+    if (response.ok) {
+      showToast(editingMethod.value ? 'Metodo actualizado' : 'Metodo creado')
+      showForm.value = false
+      loadData()
+    } else {
+      const data = await response.json()
+      showToast(data.error || 'Error al guardar', 'danger')
+    }
+  } catch (error) {
+    showToast('Error al guardar', 'danger')
+  } finally {
+    saving.value = false
+  }
+}
+
+const deleteMethod = async (method) => {
+  if (!confirm(`Eliminar "${method.label}"?`)) return
+  try {
+    const response = await fetch(`/api/venues/${venueId}/payment-methods/${method.id}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    if (response.ok) {
+      showToast('Metodo eliminado')
+      loadData()
+    } else {
+      showToast('Error al eliminar', 'danger')
+    }
+  } catch (error) {
+    showToast('Error al eliminar', 'danger')
+  }
+}
+
+onMounted(loadData)
+</script>
+
+<style scoped>
+.payment-method-card {
+  padding: 0.75rem;
+  border: 1px solid #dee2e6;
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+  transition: background-color 0.2s;
+}
+.payment-method-card:hover {
+  background-color: #f8f9fa;
+}
+</style>

--- a/src/views/venues/WhatsAppConnectionView.vue
+++ b/src/views/venues/WhatsAppConnectionView.vue
@@ -242,6 +242,77 @@
         </CCardBody>
       </CCard>
 
+      <!-- Message Stats -->
+      <CCard v-if="status === 'connected' || status === 'disconnected'" class="mb-4">
+        <CCardHeader>
+          <strong>Estadísticas de Mensajes</strong>
+        </CCardHeader>
+        <CCardBody>
+          <CSpinner v-if="loadingStats" size="sm" />
+          <div v-else>
+            <div class="row text-center mb-3">
+              <div class="col">
+                <div class="fs-4 fw-semibold">{{ stats.total_sent }}</div>
+                <small class="text-body-secondary">Enviados</small>
+              </div>
+              <div class="col">
+                <div class="fs-4 fw-semibold">{{ stats.total_delivered }}</div>
+                <small class="text-body-secondary">Entregados</small>
+              </div>
+              <div class="col">
+                <div class="fs-4 fw-semibold">{{ stats.total_read }}</div>
+                <small class="text-body-secondary">Leídos</small>
+              </div>
+              <div class="col">
+                <div class="fs-4 fw-semibold" :class="{ 'text-danger': stats.total_failed > 0 }">{{ stats.total_failed }}</div>
+                <small class="text-body-secondary">Fallidos</small>
+              </div>
+              <div class="col">
+                <div class="fs-4 fw-semibold" :class="{ 'text-warning': stats.total_pending > 0 }">{{ stats.total_pending }}</div>
+                <small class="text-body-secondary">Pendientes</small>
+              </div>
+            </div>
+            <p v-if="stats.last_message_at" class="text-body-secondary small mb-0">
+              Último mensaje: {{ formatDate(stats.last_message_at) }}
+            </p>
+            <CAlert v-if="stats.total_failed > 0" color="danger" class="mt-2 small py-2 mb-0">
+              Hay {{ stats.total_failed }} mensaje(s) fallido(s). Revisa el historial de eventos para más detalles.
+            </CAlert>
+          </div>
+        </CCardBody>
+      </CCard>
+
+      <!-- Event History -->
+      <CCard v-if="status === 'connected' || status === 'disconnected'" class="mb-4">
+        <CCardHeader class="d-flex justify-content-between align-items-center">
+          <strong>Historial de Conexión</strong>
+          <CButton color="secondary" variant="ghost" size="sm" @click="fetchEvents">
+            Actualizar
+          </CButton>
+        </CCardHeader>
+        <CCardBody>
+          <CSpinner v-if="loadingEvents" size="sm" />
+          <div v-else-if="events.length === 0" class="text-body-secondary text-center py-3">
+            No hay eventos registrados
+          </div>
+          <div v-else class="event-list" style="max-height: 300px; overflow-y: auto;">
+            <div v-for="evt in events" :key="evt.id" class="d-flex align-items-start gap-2 py-2 border-bottom">
+              <span class="event-dot" :class="eventDotClass(evt.event_type)"></span>
+              <div class="flex-grow-1">
+                <div class="small">
+                  <strong>{{ eventLabel(evt.event_type) }}</strong>
+                  <span v-if="evt.phone" class="text-body-secondary ms-1">{{ evt.phone }}</span>
+                </div>
+                <div v-if="evt.details" class="text-body-secondary small text-truncate" style="max-width: 400px;" :title="evt.details">
+                  {{ evt.details }}
+                </div>
+              </div>
+              <small class="text-body-secondary text-nowrap">{{ formatDate(evt.created_at) }}</small>
+            </div>
+          </div>
+        </CCardBody>
+      </CCard>
+
       <!-- Conversations list link -->
       <CCard v-if="status === 'connected'" class="mb-4">
         <CCardHeader><strong>Conversaciones WhatsApp</strong></CCardHeader>
@@ -282,6 +353,12 @@ const qrCanvas = ref(null)
 const excludedPhones = ref([])
 const newPhone = ref('')
 const newLabel = ref('')
+
+// Stats & Events
+const stats = ref({ total_sent: 0, total_delivered: 0, total_read: 0, total_failed: 0, total_pending: 0, last_message_at: null })
+const loadingStats = ref(false)
+const events = ref([])
+const loadingEvents = ref(false)
 
 // Escalation config
 const escConfig = ref({
@@ -490,6 +567,65 @@ async function saveEscalationConfig() {
   }
 }
 
+async function fetchStats() {
+  loadingStats.value = true
+  try {
+    const res = await fetch(`/api/venues/${venueId}/whatsapp/stats`, { credentials: 'include' })
+    if (res.ok) {
+      stats.value = await res.json()
+    }
+  } catch (err) {
+    console.error('[whatsapp-ui] Error fetching stats:', err)
+  } finally {
+    loadingStats.value = false
+  }
+}
+
+async function fetchEvents() {
+  loadingEvents.value = true
+  try {
+    const res = await fetch(`/api/venues/${venueId}/whatsapp/events?limit=50`, { credentials: 'include' })
+    if (res.ok) {
+      events.value = await res.json()
+    }
+  } catch (err) {
+    console.error('[whatsapp-ui] Error fetching events:', err)
+  } finally {
+    loadingEvents.value = false
+  }
+}
+
+const EVENT_LABELS = {
+  connected: 'Conectado',
+  disconnected: 'Desconectado',
+  qr_generated: 'QR generado',
+  message_received: 'Mensaje recibido',
+  message_sent: 'Mensaje enviado',
+  message_failed: 'Mensaje fallido',
+  error: 'Error',
+  reconnect_attempt: 'Intento de reconexión',
+  max_retries_reached: 'Reintentos agotados'
+}
+
+function eventLabel(type) {
+  return EVENT_LABELS[type] || type
+}
+
+function eventDotClass(type) {
+  const map = {
+    connected: 'dot-success',
+    disconnected: 'dot-danger',
+    message_sent: 'dot-success',
+    message_received: 'dot-info',
+    message_failed: 'dot-danger',
+    error: 'dot-danger',
+    qr_generated: 'dot-warning',
+    reconnect_attempt: 'dot-warning',
+    max_retries_reached: 'dot-danger'
+  }
+  return map[type] || 'dot-secondary'
+}
+
 function formatDate(dateStr) {
   if (!dateStr) return ''
   return new Date(dateStr).toLocaleString('es-CO', {
@@ -513,6 +649,8 @@ onMounted(async () => {
   await fetchStatus()
   await fetchExcludedPhones()
   await fetchEscalationConfig()
+  fetchStats()
+  fetchEvents()
   // Start polling if QR pending
   if (status.value === 'qr_pending') {
     startPolling()
@@ -536,4 +674,17 @@ onUnmounted(() => {
   display: block;
   margin: 0 auto;
 }
+
+.event-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 6px;
+  flex-shrink: 0;
+}
+.dot-success { background-color: #2eb85c; }
+.dot-danger { background-color: #e55353; }
+.dot-warning { background-color: #f9b115; }
+.dot-info { background-color: #3399ff; }
+.dot-secondary { background-color: #9da5b1; }
 </style>


### PR DESCRIPTION
## Summary

- **Venue Payment Methods**: New `venue_payment_methods` table with full CRUD, QR image upload (Cloudinary), and public endpoint for the venue page
- **WhatsApp Image Support**: Send/receive images in the Baileys microservice — incoming images are uploaded to Cloudinary and displayed in chat
- **AI Payment Tools**: `get_payment_methods` lists available methods; `send_payment_info` sends QR/account data to the client and tracks payment status on the estimate
- **Auto Receipt Detection**: When a client sends an image while an estimate has `payment_status: 'qr_sent'`, the system auto-creates a payment record, updates the estimate to `receipt_received`, and notifies the venue owner via system WhatsApp
- **Payment Verification**: Admin verifies payment → estimate moves to `verified` → client receives WhatsApp confirmation
- **Frontend**: Payment methods management view, chat image rendering with modal, estimate payment status badges, public venue payment methods section, commission percentage in venue form

## Flow

```
AI creates estimate → get_payment_methods → client chooses → send_payment_info (QR/data sent)
→ client sends receipt photo → auto-detected → venue notified → admin verifies → client confirmed
```

## Schema Changes

- New table: `venue_payment_methods`
- `venues`: added `commission_percentage`
- `chat_messages`: added `media_url`, `media_type`
- `estimates`: added `payment_status`, `payment_id`, `receipt_url`, `payment_method_id`

## Test plan

- [ ] Configure payment methods for a venue (Nequi, Daviplata, Bancolombia) with QR images
- [ ] WhatsApp chat: AI creates estimate → lists payment methods → client chooses → QR sent
- [ ] Client sends receipt photo → appears in admin chat with image → estimate shows `receipt_received`
- [ ] Admin verifies payment → client gets WhatsApp confirmation → estimate shows `verified`
- [ ] Public venue page shows payment methods section
- [ ] Commission percentage saves correctly in venue form

🤖 Generated with [Claude Code](https://claude.com/claude-code)