### PR TITLE
fix: Use upsert for excluded-phones endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6577,9 +6577,10 @@ REGLAS:
         entry.phone = entry.phone.replace(/\D/g, '');
       }
 
-      await prisma.whatsapp_connections.update({
+      await prisma.whatsapp_connections.upsert({
         where: { venue_id: venueId },
-        data: { excluded_phones, updated_at: new Date() }
+        update: { excluded_phones, updated_at: new Date() },
+        create: { venue_id: venueId, excluded_phones, status: 'disconnected' }
       });
 
       res.json({ success: true, excluded_phones });


### PR DESCRIPTION
## Summary
- Changed `prisma.whatsapp_connections.update()` to `upsert()` in `PUT /api/venues/:id/whatsapp/excluded-phones`
- Fixes error "No record was found for an update" when the venue has no `whatsapp_connections` record yet
- Creates the record with `status: 'disconnected'` if it doesn't exist

## Test plan
- [x] Tested locally: PUT with no existing record → creates record successfully
- [x] Tested locally: PUT with existing record → updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)