### PR TITLE
feat: Integrate Meta WhatsApp Cloud API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ const llmService = require('./llm-service');
 
 // WhatsApp service — proxied to external Baileys microservice via HTTP
 const whatsappClient = require('./services/whatsappClient');
+const metaWhatsApp = require('./services/metaWhatsApp');
 
 /**
  * Calculate the next resume time at given hour in America/Bogota timezone.
@@ -2035,11 +2036,11 @@ async function startServer() {
             const conv = await prisma.chat_conversations.findUnique({
               where: { id: linkedEstimate.conversation_id }
             });
-            if (conv?.phone && conv?.venue_id && whatsappClient.isAvailable()) {
+            if (conv?.phone && conv?.venue_id) {
               try {
                 const venueForNotif = await prisma.venues.findUnique({ where: { id: conv.venue_id } });
                 const confirmMsg = `✅ *¡Pago Verificado!*\n\n¡Hola ${conv.name || ''}! Tu pago ha sido verificado exitosamente. Tu reserva en *${venueForNotif?.name || 'la cabaña'}* está confirmada.\n\n¡Te esperamos! 🎉`;
-                await whatsappClient.sendMessage(conv.venue_id, conv.phone, confirmMsg);
+                await sendWhatsAppReply(conv.venue_id, conv.phone, confirmMsg);
               } catch (notifErr) {
                 console.error('[payment-verify] Failed to notify client:', notifErr.message);
               }
@@ -6738,10 +6739,10 @@ REGLAS:
         }
       });
 
-      // Send greeting to client if baileys conversation
-      if (conversation.phone && conversation.source === 'baileys' && whatsappClient.isAvailable()) {
+      // Send greeting to client if WhatsApp conversation
+      if (conversation.phone && (conversation.source === 'baileys' || conversation.source === 'cloud_api')) {
         try {
-          await whatsappClient.sendMessage(
+          await sendWhatsAppReply(
             venue_id,
             conversation.phone,
             '¡Hola! 👋 CabanIA está disponible nuevamente para ayudarte. ¿En qué puedo asistirte?'
@@ -6849,9 +6850,9 @@ REGLAS:
     try {
       const { id } = req.params;
 
-      // Get conversations for this venue with source baileys
+      // Get conversations for this venue with source baileys or cloud_api
       const conversations = await prisma.chat_conversations.findMany({
-        where: { venue_id: id, source: 'baileys' },
+        where: { venue_id: id, source: { in: ['baileys', 'cloud_api'] } },
         select: { id: true }
       });
       const convIds = conversations.map(c => c.id);
@@ -6970,6 +6971,384 @@ REGLAS:
       res.status(500).json({ error: error.message });
     }
   });
+
+  // ==================== Meta WhatsApp Cloud API Webhook ====================
+
+  // GET /api/webhook/whatsapp — Meta verification challenge
+  app.get('/api/webhook/whatsapp', (req, res) => {
+    const mode = req.query['hub.mode'];
+    const token = req.query['hub.verify_token'];
+    const challenge = req.query['hub.challenge'];
+
+    const verifyToken = process.env.META_WEBHOOK_VERIFY_TOKEN;
+    if (mode === 'subscribe' && token === verifyToken) {
+      console.log('[meta-webhook] Verification successful');
+      return res.status(200).send(challenge);
+    }
+    console.warn('[meta-webhook] Verification failed', { mode, token: token?.slice(0, 6) });
+    res.sendStatus(403);
+  });
+
+  // POST /api/webhook/whatsapp — Incoming messages & status updates from Meta
+  app.post('/api/webhook/whatsapp', (req, res) => {
+    // Respond 200 immediately — Meta retries if >20s
+    res.sendStatus(200);
+
+    // Process async
+    (async () => {
+      try {
+        const entry = req.body?.entry?.[0];
+        const changes = entry?.changes?.[0];
+        const value = changes?.value;
+        if (!value) return;
+
+        const phoneNumberId = value.metadata?.phone_number_id;
+        if (!phoneNumberId) return;
+
+        // Find venue by meta_phone_number_id
+        const conn = await prisma.whatsapp_connections.findFirst({
+          where: { meta_phone_number_id: phoneNumberId, channel: 'cloud_api' }
+        });
+        if (!conn) {
+          console.warn(`[meta-webhook] No venue found for phone_number_id=${phoneNumberId}`);
+          return;
+        }
+        const venue_id = conn.venue_id;
+
+        // Handle incoming messages
+        if (value.messages && value.messages.length > 0) {
+          for (const msg of value.messages) {
+            try {
+              const from = msg.from; // sender phone
+              const wamid = msg.id;
+
+              // Check excluded phones
+              const excludedPhones = conn.excluded_phones || [];
+              if (excludedPhones.some(e => from.includes(e.phone) || e.phone.includes(from))) {
+                console.log(`[meta-webhook] Skipping excluded phone ${from}`);
+                continue;
+              }
+
+              // Extract message content
+              let userMessage = '';
+              let media_url = null;
+              let media_type = null;
+
+              if (msg.type === 'text') {
+                userMessage = msg.text?.body || '';
+              } else if (msg.type === 'image') {
+                // Download image and upload to Cloudinary
+                try {
+                  const imageBuffer = await metaWhatsApp.downloadMedia(msg.image.id, conn.meta_access_token);
+                  const { uploadImage } = require('./upload-service');
+                  const uploaded = await uploadImage(imageBuffer, { type: 'chat_media', mimetype: msg.image.mime_type || 'image/jpeg' });
+                  media_url = uploaded.secure_url;
+                  media_type = 'image';
+                  userMessage = msg.image.caption || '[Imagen]';
+                } catch (dlErr) {
+                  console.error('[meta-webhook] Failed to download/upload image:', dlErr.message);
+                  userMessage = '[Imagen no disponible]';
+                }
+              } else if (msg.type === 'audio') {
+                userMessage = '[Audio recibido - no procesable]';
+              } else if (msg.type === 'document') {
+                userMessage = '[Documento recibido]';
+              } else if (msg.type === 'location') {
+                userMessage = `[Ubicación: ${msg.location?.latitude}, ${msg.location?.longitude}]`;
+              } else if (msg.type === 'contacts') {
+                userMessage = '[Contacto compartido]';
+              } else if (msg.type === 'sticker') {
+                userMessage = '[Sticker]';
+              } else if (msg.type === 'reaction') {
+                // Ignore reactions
+                continue;
+              } else {
+                userMessage = `[${msg.type || 'mensaje'} no soportado]`;
+              }
+
+              // Find or create conversation
+              let conversation = await prisma.chat_conversations.findFirst({
+                where: { venue_id, phone: from, source: 'cloud_api' },
+                include: { messages: { orderBy: { created_at: 'asc' }, take: 20 } }
+              });
+
+              if (!conversation) {
+                // Get contact name from webhook data
+                const contactName = value.contacts?.[0]?.profile?.name || null;
+                conversation = await prisma.chat_conversations.create({
+                  data: {
+                    venue_id,
+                    phone: from,
+                    name: contactName,
+                    source: 'cloud_api',
+                    status: 'active',
+                    external_id: wamid
+                  }
+                });
+                conversation.messages = [];
+              }
+
+              // Check if conversation is escalated
+              if (conversation.status === 'human_attention') {
+                console.log(`[meta-webhook] Conversation ${conversation.id} is escalated, skipping AI`);
+                // Still save the message
+                await prisma.chat_messages.create({
+                  data: {
+                    conversation_id: conversation.id,
+                    role: 'user',
+                    content: userMessage,
+                    media_url,
+                    media_type,
+                    status: 'delivered',
+                    external_id: wamid
+                  }
+                });
+                // Mark as read
+                await metaWhatsApp.markAsRead(phoneNumberId, conn.meta_access_token, wamid).catch(() => {});
+                continue;
+              }
+
+              // Save user message
+              await prisma.chat_messages.create({
+                data: {
+                  conversation_id: conversation.id,
+                  role: 'user',
+                  content: userMessage,
+                  media_url,
+                  media_type,
+                  status: 'delivered',
+                  external_id: wamid
+                }
+              });
+
+              // Update conversation timestamp
+              await prisma.chat_conversations.update({
+                where: { id: conversation.id },
+                data: { updated_at: new Date() }
+              });
+
+              // Process with AI
+              const result = await processChat({
+                venue_id,
+                userMessage,
+                conversation,
+                source: 'cloud_api',
+                media_url,
+                media_type
+              });
+
+              // Send AI response
+              if (result?.llmResponse?.content) {
+                try {
+                  const sendResult = await metaWhatsApp.sendText(
+                    phoneNumberId, conn.meta_access_token, from, result.llmResponse.content
+                  );
+                  await prisma.chat_messages.update({
+                    where: { id: result.assistantMessage.id },
+                    data: {
+                      status: 'sent',
+                      external_id: sendResult.messages?.[0]?.id || null
+                    }
+                  });
+                } catch (sendErr) {
+                  console.error('[meta-webhook] Failed to send reply:', sendErr.message);
+                  await prisma.chat_messages.update({
+                    where: { id: result.assistantMessage.id },
+                    data: { status: 'failed', error_details: sendErr.message }
+                  });
+                }
+              }
+
+              // Mark incoming message as read
+              await metaWhatsApp.markAsRead(phoneNumberId, conn.meta_access_token, wamid).catch(() => {});
+
+            } catch (msgErr) {
+              console.error('[meta-webhook] Error processing message:', msgErr.message);
+            }
+          }
+        }
+
+        // Handle status updates
+        if (value.statuses && value.statuses.length > 0) {
+          for (const status of value.statuses) {
+            try {
+              const statusMap = { sent: 'sent', delivered: 'delivered', read: 'read', failed: 'failed' };
+              const mappedStatus = statusMap[status.status];
+              if (!mappedStatus) continue;
+
+              const wamid = status.id;
+              // Find message by external_id
+              const message = await prisma.chat_messages.findFirst({
+                where: { external_id: wamid }
+              });
+              if (message) {
+                const updateData = { status: mappedStatus };
+                if (mappedStatus === 'failed' && status.errors?.[0]) {
+                  updateData.error_details = `${status.errors[0].code}: ${status.errors[0].title}`;
+                }
+                await prisma.chat_messages.update({
+                  where: { id: message.id },
+                  data: updateData
+                });
+              }
+            } catch (stErr) {
+              console.error('[meta-webhook] Error processing status:', stErr.message);
+            }
+          }
+        }
+
+      } catch (err) {
+        console.error('[meta-webhook] Unhandled error:', err);
+      }
+    })();
+  });
+
+  // ==================== WhatsApp Cloud API Config ====================
+
+  // GET /api/venues/:id/whatsapp/cloud-config — Get Cloud API config (super_admin only)
+  app.get('/api/venues/:id/whatsapp/cloud-config', isAuthenticated, async (req, res) => {
+    try {
+      const userId = String(req.user.claims.sub);
+      const currentUser = await prisma.users.findUnique({ where: { id: userId } });
+      if (!currentUser?.is_super_admin) {
+        return res.status(403).json({ error: 'Solo super admin' });
+      }
+
+      const conn = await prisma.whatsapp_connections.findUnique({
+        where: { venue_id: req.params.id }
+      });
+
+      res.json({
+        channel: conn?.channel || 'baileys',
+        meta_phone_number_id: conn?.meta_phone_number_id || '',
+        meta_access_token: conn?.meta_access_token ? '••••••' : '',
+        meta_verify_token: conn?.meta_verify_token || '',
+        has_token: !!conn?.meta_access_token
+      });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // PUT /api/venues/:id/whatsapp/cloud-config — Save Cloud API config (super_admin only)
+  app.put('/api/venues/:id/whatsapp/cloud-config', isAuthenticated, async (req, res) => {
+    try {
+      const userId = String(req.user.claims.sub);
+      const currentUser = await prisma.users.findUnique({ where: { id: userId } });
+      if (!currentUser?.is_super_admin) {
+        return res.status(403).json({ error: 'Solo super admin' });
+      }
+
+      const { channel, meta_phone_number_id, meta_access_token, meta_verify_token } = req.body;
+      const venue_id = req.params.id;
+
+      const updateData = {
+        channel: channel || 'baileys',
+        meta_phone_number_id: meta_phone_number_id || null,
+        meta_verify_token: meta_verify_token || null,
+        updated_at: new Date()
+      };
+
+      // Only update token if a new one is provided (not the masked placeholder)
+      if (meta_access_token && meta_access_token !== '••••••') {
+        updateData.meta_access_token = meta_access_token;
+      }
+
+      // If switching to cloud_api and status is disconnected, set to connected
+      if (channel === 'cloud_api' && meta_phone_number_id && (meta_access_token || updateData.meta_access_token)) {
+        updateData.status = 'connected';
+      }
+
+      await prisma.whatsapp_connections.upsert({
+        where: { venue_id },
+        update: updateData,
+        create: {
+          venue_id,
+          ...updateData,
+          excluded_phones: [],
+          escalation_config: {}
+        }
+      });
+
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // POST /api/venues/:id/whatsapp/cloud-test — Send test template message (super_admin only)
+  app.post('/api/venues/:id/whatsapp/cloud-test', isAuthenticated, async (req, res) => {
+    try {
+      const userId = String(req.user.claims.sub);
+      const currentUser = await prisma.users.findUnique({ where: { id: userId } });
+      if (!currentUser?.is_super_admin) {
+        return res.status(403).json({ error: 'Solo super admin' });
+      }
+
+      const { to } = req.body;
+      if (!to) return res.status(400).json({ error: 'Se requiere número de destino (to)' });
+
+      const conn = await prisma.whatsapp_connections.findUnique({
+        where: { venue_id: req.params.id }
+      });
+      if (!conn?.meta_phone_number_id || !conn?.meta_access_token) {
+        return res.status(400).json({ error: 'Cloud API no configurada para este venue' });
+      }
+
+      const result = await metaWhatsApp.sendTemplate(
+        conn.meta_phone_number_id, conn.meta_access_token, to, 'hello_world', 'en_US'
+      );
+
+      res.json({ success: true, message_id: result.messages?.[0]?.id });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // ==================== WhatsApp Send Helpers ====================
+
+  /**
+   * Send a text reply via the appropriate WhatsApp channel (Cloud API or Baileys).
+   * Returns the send result or null if no channel is available.
+   */
+  async function sendWhatsAppReply(venue_id, phone, text, messageId) {
+    const conn = await prisma.whatsapp_connections.findUnique({ where: { venue_id } });
+    if (conn?.channel === 'cloud_api' && conn.meta_phone_number_id && conn.meta_access_token) {
+      const result = await metaWhatsApp.sendText(conn.meta_phone_number_id, conn.meta_access_token, phone, text);
+      if (messageId) {
+        await prisma.chat_messages.update({
+          where: { id: messageId },
+          data: { status: 'sent', external_id: result.messages?.[0]?.id || null }
+        });
+      }
+      return result;
+    } else if (whatsappClient.isAvailable()) {
+      return whatsappClient.sendMessage(venue_id, phone, text);
+    }
+    return null;
+  }
+
+  /**
+   * Send an image via the appropriate WhatsApp channel.
+   */
+  async function sendWhatsAppImage(venue_id, phone, imageUrl, caption) {
+    const conn = await prisma.whatsapp_connections.findUnique({ where: { venue_id } });
+    if (conn?.channel === 'cloud_api' && conn.meta_phone_number_id && conn.meta_access_token) {
+      return metaWhatsApp.sendImage(conn.meta_phone_number_id, conn.meta_access_token, phone, imageUrl, caption);
+    } else if (whatsappClient.isAvailable()) {
+      return whatsappClient.sendImage(venue_id, phone, imageUrl, caption);
+    }
+    return null;
+  }
+
+  /**
+   * Check if any WhatsApp channel is available for a venue.
+   */
+  async function isWhatsAppAvailable(venue_id) {
+    const conn = await prisma.whatsapp_connections.findUnique({ where: { venue_id } });
+    if (conn?.channel === 'cloud_api' && conn.meta_phone_number_id && conn.meta_access_token) return true;
+    return whatsappClient.isAvailable();
+  }
 
   // ==================== Chat API ====================
 
@@ -7587,13 +7966,13 @@ REGLAS:
             if (paymentMethod.instructions) caption += `\n\n📝 ${paymentMethod.instructions}`;
             caption += '\n\n📸 Una vez realices el pago, envía la foto del comprobante por este chat.';
 
-            // Send QR image or text via WhatsApp if source is baileys
-            if (source === 'baileys' && conversation.phone && whatsappClient.isAvailable()) {
+            // Send QR image or text via WhatsApp if source is baileys or cloud_api
+            if ((source === 'baileys' || source === 'cloud_api') && conversation.phone) {
               try {
                 if (paymentMethod.qr_image_url) {
-                  await whatsappClient.sendImage(venue_id, conversation.phone, paymentMethod.qr_image_url, caption);
+                  await sendWhatsAppImage(venue_id, conversation.phone, paymentMethod.qr_image_url, caption);
                 } else {
-                  await whatsappClient.sendMessage(venue_id, conversation.phone, caption);
+                  await sendWhatsAppReply(venue_id, conversation.phone, caption);
                 }
               } catch (sendErr) {
                 console.error('[payment] Failed to send payment info via WhatsApp:', sendErr.message);
@@ -7943,7 +8322,7 @@ REGLAS:
           content: userMessage,
           media_url: media_url || null,
           media_type: media_type || null,
-          status: source === 'baileys' ? 'delivered' : null
+          status: (source === 'baileys' || source === 'cloud_api') ? 'delivered' : null
         }
       });
 
@@ -8039,15 +8418,10 @@ REGLAS:
         userId: req.user?.id
       });
 
-      // If source is baileys, send the response via WhatsApp
-      if (source === 'baileys' && conversation.phone && whatsappClient.isAvailable()) {
+      // If source is WhatsApp (baileys or cloud_api), send the response
+      if ((source === 'baileys' || source === 'cloud_api') && conversation.phone) {
         try {
-          await whatsappClient.sendMessage(venue_id, conversation.phone, result.llmResponse.content);
-          // Update status to sent
-          await prisma.chat_messages.update({
-            where: { id: result.assistantMessage.id },
-            data: { status: 'sent' }
-          });
+          await sendWhatsAppReply(venue_id, conversation.phone, result.llmResponse.content, result.assistantMessage.id);
         } catch (sendErr) {
           console.error('[reprocess] Failed to send via WhatsApp:', sendErr.message);
           await prisma.chat_messages.update({
@@ -8096,19 +8470,13 @@ REGLAS:
         return res.status(400).json({ error: 'La conversación no tiene número de teléfono asociado' });
       }
 
-      if (!whatsappClient.isAvailable()) {
+      if (!(await isWhatsAppAvailable(venue_id))) {
         return res.status(503).json({ error: 'Servicio de WhatsApp no disponible' });
       }
 
       try {
-        const result = await whatsappClient.sendMessage(venue_id, phone, message.content);
-        const updated = await prisma.chat_messages.update({
-          where: { id: message_id },
-          data: {
-            status: 'sent',
-            external_id: result?.messageId || result?.id || null
-          }
-        });
+        await sendWhatsAppReply(venue_id, phone, message.content, message_id);
+        const updated = await prisma.chat_messages.findUnique({ where: { id: message_id } });
         res.json({ status: updated.status, external_id: updated.external_id });
       } catch (sendErr) {
         console.error('[send-whatsapp] Failed:', sendErr.message);

--- a/server/index.js
+++ b/server/index.js
@@ -8492,18 +8492,65 @@ REGLAS:
     }
   });
 
-  // GET /api/chat/:venue_id/conversations - List conversations for a venue
+  // GET /api/chat/:venue_id/conversations - List conversations for a venue (inbox)
   app.get('/api/chat/:venue_id/conversations', isAuthenticated, async (req, res) => {
     try {
       const { venue_id } = req.params;
-      
+      const { search, source } = req.query;
+
+      const where = { venue_id };
+
+      // Filter by source channels (comma-separated)
+      if (source) {
+        where.source = { in: source.split(',').map(s => s.trim()) };
+      }
+
+      // Search by name or phone
+      if (search) {
+        where.OR = [
+          { name: { contains: search, mode: 'insensitive' } },
+          { phone: { contains: search } }
+        ];
+      }
+
       const conversations = await prisma.chat_conversations.findMany({
-        where: { venue_id },
+        where,
         orderBy: { updated_at: 'desc' },
-        take: 50
+        take: 50,
+        include: {
+          messages: {
+            orderBy: { created_at: 'desc' },
+            take: 1,
+            select: { content: true, role: true, created_at: true, provider: true }
+          }
+        }
       });
-      
-      res.json(conversations);
+
+      // Add last_message preview and unread_count
+      const result = await Promise.all(conversations.map(async (conv) => {
+        const lastMsg = conv.messages[0] || null;
+        // Count user messages after last_read_at
+        let unread_count = 0;
+        const unreadWhere = { conversation_id: conv.id, role: 'user' };
+        if (conv.last_read_at) {
+          unreadWhere.created_at = { gt: conv.last_read_at };
+        }
+        unread_count = await prisma.chat_messages.count({ where: unreadWhere });
+
+        const { messages, ...convData } = conv;
+        return {
+          ...convData,
+          last_message: lastMsg ? {
+            content: (lastMsg.content || '').substring(0, 100),
+            role: lastMsg.role,
+            created_at: lastMsg.created_at,
+            provider: lastMsg.provider
+          } : null,
+          unread_count
+        };
+      }));
+
+      res.json(result);
     } catch (error) {
       res.status(500).json({ error: error.message });
     }
@@ -8516,9 +8563,93 @@ REGLAS:
         where: { id: req.params.id },
         include: { messages: { orderBy: { created_at: 'asc' } } }
       });
-      
+
+      // Mark as read
+      if (conversation) {
+        await prisma.chat_conversations.update({
+          where: { id: req.params.id },
+          data: { last_read_at: new Date() }
+        });
+      }
+
       res.json(conversation);
     } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // POST /api/chat/:venue_id/conversations/:id/admin-reply - Send manual admin reply
+  app.post('/api/chat/:venue_id/conversations/:id/admin-reply', isAuthenticated, async (req, res) => {
+    try {
+      const { venue_id, id } = req.params;
+      const { text } = req.body;
+      if (!text || !text.trim()) {
+        return res.status(400).json({ error: 'Text is required' });
+      }
+
+      const conversation = await prisma.chat_conversations.findUnique({ where: { id } });
+      if (!conversation || conversation.venue_id !== venue_id) {
+        return res.status(404).json({ error: 'Conversation not found' });
+      }
+
+      // Save as assistant message with provider 'admin'
+      const message = await prisma.chat_messages.create({
+        data: {
+          conversation_id: id,
+          role: 'assistant',
+          content: text.trim(),
+          provider: 'admin',
+          status: 'pending'
+        }
+      });
+
+      // Update conversation timestamp
+      await prisma.chat_conversations.update({
+        where: { id },
+        data: { updated_at: new Date(), last_read_at: new Date() }
+      });
+
+      // Send via WhatsApp if the conversation has a phone number
+      if (conversation.phone && conversation.source !== 'web') {
+        try {
+          await sendWhatsAppReply(venue_id, conversation.phone, text.trim(), message.id);
+        } catch (waError) {
+          console.error('Admin reply WhatsApp send error:', waError);
+          await prisma.chat_messages.update({
+            where: { id: message.id },
+            data: { status: 'failed', error_details: waError.message }
+          });
+          return res.json({ ...message, status: 'failed', error_details: waError.message });
+        }
+      } else {
+        // Web channel — just mark as sent (user will see on page reload)
+        await prisma.chat_messages.update({
+          where: { id: message.id },
+          data: { status: 'sent' }
+        });
+        message.status = 'sent';
+      }
+
+      res.json(message);
+    } catch (error) {
+      console.error('Admin reply error:', error);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // DELETE /api/chat/:venue_id/conversations/:id - Delete a conversation and its messages
+  app.delete('/api/chat/:venue_id/conversations/:id', isAuthenticated, async (req, res) => {
+    try {
+      const { venue_id, id } = req.params;
+      const conversation = await prisma.chat_conversations.findUnique({ where: { id } });
+      if (!conversation || conversation.venue_id !== venue_id) {
+        return res.status(404).json({ error: 'Conversation not found' });
+      }
+      // Messages cascade-delete via schema relation (onDelete: Cascade)
+      await prisma.chat_conversations.delete({ where: { id } });
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Delete conversation error:', error);
       res.status(500).json({ error: error.message });
     }
   });

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -950,18 +950,22 @@ model app_settings {
 // ========================================
 
 model whatsapp_connections {
-  id                 String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  venue_id           String    @unique @db.Uuid
-  phone_number       String?   @db.VarChar(50)
-  status             String    @default("disconnected") @db.VarChar(30) // disconnected | qr_pending | connected | banned
-  session_data       Json?     @db.Json
-  qr_code            String?   @db.Text
-  excluded_phones    Json      @default("[]") @db.Json // Array of {phone, label} objects
-  notification_phone String?   @db.VarChar(50)
-  escalation_config  Json      @default("{}") @db.Json
-  last_connected     DateTime? @db.Timestamptz(6)
-  created_at         DateTime  @default(now()) @db.Timestamptz(6)
-  updated_at         DateTime? @db.Timestamptz(6)
+  id                   String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  venue_id             String    @unique @db.Uuid
+  phone_number         String?   @db.VarChar(50)
+  status               String    @default("disconnected") @db.VarChar(30) // disconnected | qr_pending | connected | banned
+  session_data         Json?     @db.Json
+  qr_code              String?   @db.Text
+  excluded_phones      Json      @default("[]") @db.Json // Array of {phone, label} objects
+  notification_phone   String?   @db.VarChar(50)
+  escalation_config    Json      @default("{}") @db.Json
+  last_connected       DateTime? @db.Timestamptz(6)
+  created_at           DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at           DateTime? @db.Timestamptz(6)
+  channel              String    @default("baileys") @db.VarChar(20)
+  meta_phone_number_id String?   @db.VarChar(50)
+  meta_access_token    String?
+  meta_verify_token    String?   @db.VarChar(100)
 }
 
 model system_whatsapp_connection {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -498,6 +498,7 @@ model chat_conversations {
   escalated_at     DateTime?       @db.Timestamptz(6)
   escalated_reason String?         @db.VarChar(50)
   resume_at        DateTime?       @db.Timestamptz(6)
+  last_read_at     DateTime?       @db.Timestamptz(6)
   created_at       DateTime        @default(now()) @db.Timestamptz(6)
   updated_at       DateTime?       @db.Timestamptz(6)
   messages         chat_messages[]

--- a/server/services/metaWhatsApp.js
+++ b/server/services/metaWhatsApp.js
@@ -1,0 +1,107 @@
+/**
+ * Meta WhatsApp Cloud API Service
+ *
+ * Sends messages, downloads media, and marks messages as read
+ * via the official Graph API v22.0.
+ */
+
+const GRAPH_API = 'https://graph.facebook.com/v22.0';
+
+async function graphRequest(url, token, options = {}) {
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...options.headers
+    }
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Graph API ${res.status}: ${body}`);
+  }
+  return options.raw ? res : res.json();
+}
+
+/**
+ * Send a text message.
+ * @returns {{ messaging_product, contacts, messages }} — messages[0].id is the wamid
+ */
+async function sendText(phoneNumberId, token, to, text) {
+  return graphRequest(`${GRAPH_API}/${phoneNumberId}/messages`, token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      messaging_product: 'whatsapp',
+      to,
+      type: 'text',
+      text: { body: text }
+    })
+  });
+}
+
+/**
+ * Send an image message with optional caption.
+ */
+async function sendImage(phoneNumberId, token, to, imageUrl, caption) {
+  const payload = {
+    messaging_product: 'whatsapp',
+    to,
+    type: 'image',
+    image: { link: imageUrl }
+  };
+  if (caption) payload.image.caption = caption;
+
+  return graphRequest(`${GRAPH_API}/${phoneNumberId}/messages`, token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+}
+
+/**
+ * Send a template message (e.g. hello_world for testing).
+ */
+async function sendTemplate(phoneNumberId, token, to, templateName, lang = 'en_US') {
+  return graphRequest(`${GRAPH_API}/${phoneNumberId}/messages`, token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      messaging_product: 'whatsapp',
+      to,
+      type: 'template',
+      template: {
+        name: templateName,
+        language: { code: lang }
+      }
+    })
+  });
+}
+
+/**
+ * Download media by its ID. Returns a Buffer.
+ */
+async function downloadMedia(mediaId, token) {
+  // Step 1: get the media URL
+  const meta = await graphRequest(`${GRAPH_API}/${mediaId}`, token);
+  // Step 2: download the actual binary
+  const res = await graphRequest(meta.url, token, { raw: true });
+  const arrayBuffer = await res.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+/**
+ * Mark a message as read.
+ */
+async function markAsRead(phoneNumberId, token, messageId) {
+  return graphRequest(`${GRAPH_API}/${phoneNumberId}/messages`, token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      messaging_product: 'whatsapp',
+      status: 'read',
+      message_id: messageId
+    })
+  });
+}
+
+module.exports = { sendText, sendImage, sendTemplate, downloadMedia, markAsRead };

--- a/src/views/venues/VenueChatView.vue
+++ b/src/views/venues/VenueChatView.vue
@@ -1,210 +1,188 @@
 <template>
-  <CRow>
-    <CCol :xs="12" :lg="10" :xl="8" class="mx-auto">
-      <CCard class="mb-4">
-        <CCardHeader class="d-flex justify-content-between align-items-center">
-          <div>
-            <strong>Chat de Prueba</strong>
-            <span v-if="venue" class="text-muted ms-2">- {{ venue.name }}</span>
-          </div>
-          <div class="d-flex align-items-center gap-2">
-            <CFormSelect v-if="isDev" v-model="selectedProviderId" size="sm" style="width: auto; min-width: 180px;">
-              <option value="">Seleccionar proveedor</option>
-              <option v-for="provider in providers" :key="provider.id" :value="provider.id">
-                {{ provider.name }} ({{ provider.model }})
-              </option>
-            </CFormSelect>
-            <CButton color="secondary" size="sm" variant="outline" @click="clearConversation">
-              <CIcon name="cil-chat-bubble" class="me-1" /> Nueva
-            </CButton>
-          </div>
-        </CCardHeader>
-        <CCardBody class="p-0">
-          <div class="contact-input-bar">
-            <div v-if="activeConvSource && activeConvSource !== 'web'" class="d-flex align-items-center gap-2">
-              <CBadge :color="getSourceColor(activeConvSource)">{{ getSourceLabel(activeConvSource) }}</CBadge>
-              <strong class="small">
-                {{ activeConvPhone ? '+' + activeConvPhone : '' }}
-                <span v-if="activeConvName" class="text-muted">({{ activeConvName }})</span>
-              </strong>
-            </div>
-            <div v-else class="d-flex align-items-center gap-2">
-              <CFormSelect v-model="contactType" size="sm" style="width: auto; min-width: 130px;">
-                <option value="whatsapp">WhatsApp</option>
-                <option value="instagram">Instagram</option>
-              </CFormSelect>
-              <CFormInput
-                v-model="contactValue"
-                :placeholder="contactType === 'whatsapp' ? 'Ej: 3101234567' : 'Ej: @usuario'"
-                size="sm"
-                style="max-width: 180px;"
-              />
-              <small class="text-muted">Simular contacto del cliente</small>
-            </div>
-          </div>
-          <div class="chat-container">
-            <div class="chat-messages" ref="messagesContainer">
-              <div v-if="messages.length === 0" class="text-center text-muted py-5">
-                <CIcon name="cil-chat-bubble" size="3xl" class="mb-3" />
-                <p>Inicia una conversación enviando un mensaje</p>
-              </div>
-              <div 
-                v-for="(message, index) in messages" 
-                :key="index"
-                :class="['message-wrapper', message.role === 'user' ? 'message-user' : 'message-assistant']"
-              >
-                <div :class="['message-bubble', message.role === 'user' ? 'bubble-user' : 'bubble-assistant']">
-                  <div v-if="message.media_url" class="message-media mb-2">
-                    <img
-                      :src="message.media_url"
-                      class="chat-image"
-                      alt="Imagen"
-                      @click="openImageModal(message.media_url)"
-                    />
-                  </div>
-                  <div class="message-content">{{ message.content }}</div>
-                  <div class="message-footer">
-                    <small v-if="message.created_at" class="message-time">{{ formatTime(message.created_at) }}</small>
-                    <span v-if="message.role === 'assistant' && message.status" class="message-status ms-1" :title="message.status === 'failed' ? (message.error_details || 'Error de envío') : message.status">
-                      <span v-if="message.status === 'pending'" class="text-muted">&#9203;</span>
-                      <span v-else-if="message.status === 'sent'" class="text-muted">&#10003;</span>
-                      <span v-else-if="message.status === 'delivered'" class="text-muted">&#10003;&#10003;</span>
-                      <span v-else-if="message.status === 'read'" class="status-read">&#10003;&#10003;</span>
-                      <span v-else-if="message.status === 'failed'" class="text-danger">&#10007;</span>
-                    </span>
-                    <button
-                      v-if="message.role === 'user' && message.id && conversationId"
-                      class="btn-reprocess ms-1"
-                      :disabled="reprocessingId === message.id"
-                      :title="'Reprocesar mensaje'"
-                      @click="reprocessMessage(message)"
-                    >
-                      <CSpinner v-if="reprocessingId === message.id" size="sm" style="width: 0.7rem; height: 0.7rem;" />
-                      <span v-else>&#8635;</span>
-                    </button>
-                    <button
-                      v-if="message.role === 'assistant' && message.id && activeConvPhone"
-                      class="btn-send-wa ms-1"
-                      :disabled="sendingWaId === message.id || message.status === 'sent'"
-                      title="Enviar a WhatsApp"
-                      @click="sendToWhatsApp(message)"
-                    >
-                      <CSpinner v-if="sendingWaId === message.id" size="sm" style="width: 0.7rem; height: 0.7rem;" />
-                      <span v-else-if="message.status === 'sent'">&#10003;</span>
-                      <span v-else>&#128241;</span>
-                    </button>
-                  </div>
-                  <div v-if="isDev && message.role === 'assistant' && message.meta" class="message-meta">
-                    <small class="text-muted">
-                      {{ message.meta.model }}
-                      <span v-if="message.meta.tokens">| {{ message.meta.tokens }} tokens</span>
-                    </small>
-                  </div>
-                </div>
-              </div>
-              <div v-if="sending" class="message-wrapper message-assistant">
-                <div class="message-bubble bubble-assistant">
-                  <CSpinner size="sm" /> <span class="ms-2">Escribiendo...</span>
-                </div>
-              </div>
-            </div>
-            <div class="chat-input-container">
-              <CInputGroup>
-                <CFormInput 
-                  v-model="newMessage"
-                  placeholder="Escribe tu mensaje..."
-                  @keyup.enter="sendMessage"
-                  :disabled="sending"
-                />
-                <CButton 
-                  color="primary" 
-                  @click="sendMessage"
-                  :disabled="sending || !newMessage.trim() || !selectedProviderId"
-                >
-                  <CSpinner v-if="sending" size="sm" />
-                  <CIcon v-else name="cil-send" />
-                </CButton>
-              </CInputGroup>
-            </div>
-          </div>
-        </CCardBody>
-      </CCard>
-
-      <div class="text-center mb-4 d-flex justify-content-center gap-2">
-        <RouterLink :to="`/business/venues/${$route.params.id}`">
-          <CButton color="secondary" variant="outline" size="sm">
-            <CIcon name="cil-arrow-left" class="me-1" /> Volver a la Cabaña
-          </CButton>
-        </RouterLink>
-        <RouterLink v-if="estimateId" :to="`/business/estimates/${estimateId}`">
-          <CButton color="info" variant="outline" size="sm">
-            <CIcon name="cil-arrow-left" class="me-1" /> Volver a la Cotización
-          </CButton>
-        </RouterLink>
+  <div class="inbox-container">
+    <!-- LEFT PANEL: Conversation list -->
+    <div :class="['inbox-sidebar', { 'd-none d-md-flex': selectedConv }]">
+      <div class="sidebar-header">
+        <h6 class="mb-0">Inbox</h6>
+        <span v-if="venue" class="text-body-secondary small ms-2">{{ venue.name }}</span>
       </div>
 
-      <CCard v-if="!arrivedWithConversation" class="mb-4">
-        <CCardHeader>
-          <strong>Conversaciones Anteriores</strong>
-        </CCardHeader>
-        <CCardBody>
-          <CSpinner v-if="loadingConversations" />
-          <div v-else-if="conversations.length === 0" class="text-center text-muted py-3">
-            No hay conversaciones anteriores
+      <!-- Search -->
+      <div class="sidebar-search">
+        <CFormInput
+          v-model="searchQuery"
+          placeholder="Buscar por nombre o tel..."
+          size="sm"
+          @input="debouncedSearch"
+        />
+      </div>
+
+      <!-- Channel filters -->
+      <div class="sidebar-filters">
+        <CBadge
+          v-for="ch in channelFilters"
+          :key="ch.value"
+          :color="activeChannelFilter === ch.value ? 'primary' : 'secondary'"
+          class="filter-chip me-1"
+          role="button"
+          @click="setChannelFilter(ch.value)"
+        >
+          {{ ch.label }}
+        </CBadge>
+      </div>
+
+      <!-- Conversation list -->
+      <div class="sidebar-list">
+        <CSpinner v-if="loadingConversations && conversations.length === 0" class="m-3" />
+        <div
+          v-for="conv in conversations"
+          :key="conv.id"
+          :class="['conv-item', { active: selectedConv?.id === conv.id }]"
+          @click="selectConversation(conv)"
+        >
+          <div class="conv-avatar">
+            {{ getInitial(conv) }}
           </div>
-          <CTable v-else hover responsive small>
-            <CTableHead>
-              <CTableRow>
-                <CTableHeaderCell>Fecha</CTableHeaderCell>
-                <CTableHeaderCell>Fuente</CTableHeaderCell>
-                <CTableHeaderCell>Estado</CTableHeaderCell>
-                <CTableHeaderCell>Teléfono</CTableHeaderCell>
-                <CTableHeaderCell>Contacto</CTableHeaderCell>
-                <CTableHeaderCell></CTableHeaderCell>
-              </CTableRow>
-            </CTableHead>
-            <CTableBody>
-              <CTableRow
-                v-for="conv in conversations"
-                :key="conv.id"
-                :class="{ 'table-active': conversationId === conv.id, 'table-warning': conv.status === 'human_attention' }"
-              >
-                <CTableDataCell>{{ formatDate(conv.updated_at || conv.created_at) }}</CTableDataCell>
-                <CTableDataCell>
-                  <CBadge :color="getSourceColor(conv.source)">{{ getSourceLabel(conv.source) }}</CBadge>
-                </CTableDataCell>
-                <CTableDataCell>
-                  <CBadge v-if="conv.status === 'human_attention'" color="warning" class="text-dark">
-                    Atención humana
-                  </CBadge>
-                  <CBadge v-else color="success">Activa</CBadge>
-                </CTableDataCell>
-                <CTableDataCell>{{ conv.phone || '-' }}</CTableDataCell>
-                <CTableDataCell>{{ conv.name || '-' }}</CTableDataCell>
-                <CTableDataCell class="text-end">
-                  <CButton
-                    v-if="conv.status === 'human_attention'"
-                    size="sm"
-                    color="warning"
-                    variant="ghost"
-                    @click="resumeBotForConversation(conv)"
-                    :disabled="resumingConvId === conv.id"
-                    class="me-1"
-                  >
-                    <CSpinner v-if="resumingConvId === conv.id" size="sm" />
-                    <template v-else>Reanudar bot</template>
-                  </CButton>
-                  <CButton size="sm" color="primary" variant="ghost" @click="resumeConversation(conv)">
-                    Ver chat
-                  </CButton>
-                </CTableDataCell>
-              </CTableRow>
-            </CTableBody>
-          </CTable>
-        </CCardBody>
-      </CCard>
-    </CCol>
-  </CRow>
+          <div class="conv-info">
+            <div class="conv-top-row">
+              <span class="conv-name">{{ conv.name || conv.phone || 'Sin nombre' }}</span>
+              <span class="conv-time">{{ relativeTime(conv.last_message?.created_at || conv.updated_at) }}</span>
+            </div>
+            <div class="conv-bottom-row">
+              <span class="conv-preview">
+                <span v-if="conv.last_message?.role === 'assistant'" class="text-body-secondary">Tú: </span>
+                {{ conv.last_message?.content || 'Sin mensajes' }}
+              </span>
+              <div class="conv-badges">
+                <span v-if="conv.status === 'human_attention'" class="badge-escalation" title="Requiere atención">!</span>
+                <span v-if="conv.unread_count > 0" class="badge-unread">{{ conv.unread_count > 99 ? '99+' : conv.unread_count }}</span>
+              </div>
+            </div>
+            <div class="conv-source-row">
+              <CBadge :color="getSourceColor(conv.source)" size="sm" class="conv-source-badge">{{ getSourceLabel(conv.source) }}</CBadge>
+            </div>
+          </div>
+        </div>
+        <div v-if="!loadingConversations && conversations.length === 0" class="text-center text-body-secondary py-4">
+          No hay conversaciones
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT PANEL: Active chat -->
+    <div :class="['inbox-chat', { 'd-none d-md-flex': !selectedConv }]">
+      <!-- Empty state -->
+      <div v-if="!selectedConv" class="chat-empty">
+        <CIcon name="cil-chat-bubble" size="3xl" class="mb-3 text-body-secondary" />
+        <p class="text-body-secondary">Selecciona una conversación para ver los mensajes</p>
+      </div>
+
+      <template v-else>
+        <!-- Chat header -->
+        <div class="chat-header">
+          <button class="btn-back d-md-none me-2" @click="selectedConv = null">
+            &#8592;
+          </button>
+          <div class="chat-header-info">
+            <strong>{{ selectedConv.name || selectedConv.phone || 'Sin nombre' }}</strong>
+            <span v-if="selectedConv.phone" class="text-body-secondary small ms-2">+{{ selectedConv.phone }}</span>
+            <CBadge :color="getSourceColor(selectedConv.source)" class="ms-2" size="sm">{{ getSourceLabel(selectedConv.source) }}</CBadge>
+            <CBadge v-if="selectedConv.status === 'human_attention'" color="warning" class="ms-2 text-dark" size="sm">Escalado</CBadge>
+          </div>
+          <div class="chat-header-actions">
+            <CButton
+              v-if="selectedConv.status === 'human_attention'"
+              size="sm"
+              color="warning"
+              variant="outline"
+              :disabled="resumingBot"
+              @click="resumeBot"
+              class="me-1"
+            >
+              <CSpinner v-if="resumingBot" size="sm" />
+              <template v-else>Reanudar bot</template>
+            </CButton>
+            <CButton
+              size="sm"
+              color="danger"
+              variant="ghost"
+              :disabled="deletingConv"
+              @click="confirmDeleteConversation"
+              title="Eliminar conversación"
+            >
+              <CSpinner v-if="deletingConv" size="sm" />
+              <CIcon v-else name="cil-trash" />
+            </CButton>
+          </div>
+        </div>
+
+        <!-- Messages -->
+        <div class="chat-messages" ref="messagesContainer">
+          <div v-if="loadingMessages" class="text-center py-4">
+            <CSpinner />
+          </div>
+          <template v-else>
+            <div v-if="messages.length === 0" class="text-center text-body-secondary py-5">
+              <p>No hay mensajes en esta conversación</p>
+            </div>
+            <div
+              v-for="msg in messages"
+              :key="msg.id"
+              :class="['message-wrapper', msg.role === 'user' ? 'message-user' : 'message-assistant']"
+            >
+              <div :class="['message-bubble', msg.role === 'user' ? 'bubble-user' : 'bubble-assistant']">
+                <!-- Provider badge for assistant messages -->
+                <div v-if="msg.role === 'assistant'" class="message-provider-badge mb-1">
+                  <span v-if="msg.provider === 'admin'" class="badge-admin">Admin</span>
+                  <span v-else class="badge-ai">IA</span>
+                </div>
+
+                <div v-if="msg.media_url" class="message-media mb-2">
+                  <img :src="msg.media_url" class="chat-image" alt="Imagen" @click="imageModalUrl = msg.media_url" />
+                </div>
+                <div class="message-content">{{ msg.content }}</div>
+                <div class="message-footer">
+                  <small v-if="msg.created_at" class="message-time">{{ formatTime(msg.created_at) }}</small>
+                  <span v-if="msg.role === 'assistant' && msg.status" class="message-status ms-1" :title="msg.status === 'failed' ? (msg.error_details || 'Error') : msg.status">
+                    <span v-if="msg.status === 'pending'" class="text-body-secondary">&#9203;</span>
+                    <span v-else-if="msg.status === 'sent'" class="text-body-secondary">&#10003;</span>
+                    <span v-else-if="msg.status === 'delivered'" class="text-body-secondary">&#10003;&#10003;</span>
+                    <span v-else-if="msg.status === 'read'" class="status-read">&#10003;&#10003;</span>
+                    <span v-else-if="msg.status === 'failed'" class="text-danger">&#10007;</span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div v-if="sendingReply" class="message-wrapper message-assistant">
+              <div class="message-bubble bubble-assistant">
+                <CSpinner size="sm" /> <span class="ms-2">Enviando...</span>
+              </div>
+            </div>
+          </template>
+        </div>
+
+        <!-- Input bar -->
+        <div class="chat-input-container">
+          <CInputGroup>
+            <CFormInput
+              v-model="replyText"
+              placeholder="Escribe un mensaje..."
+              @keyup.enter="sendAdminReply"
+              :disabled="sendingReply"
+            />
+            <CButton
+              color="primary"
+              @click="sendAdminReply"
+              :disabled="sendingReply || !replyText.trim()"
+            >
+              <CSpinner v-if="sendingReply" size="sm" />
+              <CIcon v-else name="cil-send" />
+            </CButton>
+          </CInputGroup>
+        </div>
+      </template>
+    </div>
+  </div>
 
   <CToaster placement="top-end">
     <CToast v-if="toast.visible" :color="toast.color" class="text-white" :autohide="true" :delay="3000" @close="toast.visible = false">
@@ -223,83 +201,77 @@
 import { ref, onMounted, onUnmounted, nextTick, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import {
-  CRow, CCol, CCard, CCardHeader, CCardBody, CButton, CSpinner,
-  CFormSelect, CFormInput, CInputGroup,
+  CRow, CCol, CButton, CSpinner,
+  CFormInput, CInputGroup,
   CToaster, CToast, CToastBody,
-  CTable, CTableHead, CTableBody, CTableRow, CTableHeaderCell, CTableDataCell,
   CBadge, CModal, CModalBody
 } from '@coreui/vue'
 import { CIcon } from '@coreui/icons-vue'
 import { getVenueById } from '@/services/venueService'
-import { useSettingsStore } from '@/stores/settings'
 import { useBreadcrumbStore } from '@/stores/breadcrumb.js'
 
 const route = useRoute()
-const settingsStore = useSettingsStore()
 const breadcrumbStore = useBreadcrumbStore()
-const isDev = settingsStore.developmentMode
+const venueId = route.params.id
+
 const venue = ref(null)
-const providers = ref([])
-const selectedProviderId = ref('')
-const messages = ref([])
-const newMessage = ref('')
-const sending = ref(false)
-const conversationId = ref(null)
-const messagesContainer = ref(null)
-const contactType = ref('whatsapp')
-const contactValue = ref('')
 const conversations = ref([])
+const selectedConv = ref(null)
+const messages = ref([])
+const replyText = ref('')
+const searchQuery = ref('')
+const activeChannelFilter = ref('all')
 const loadingConversations = ref(false)
-const estimateId = ref(null)
-const arrivedWithConversation = ref(false)
-const resumingConvId = ref(null)
-const reprocessingId = ref(null)
-const sendingWaId = ref(null)
+const loadingMessages = ref(false)
+const sendingReply = ref(false)
+const resumingBot = ref(false)
+const deletingConv = ref(false)
 const imageModalUrl = ref(null)
-const activeConvSource = ref(null) // source of the active conversation (baileys, web, etc.)
-const activeConvPhone = ref(null)
-const activeConvName = ref(null)
+const messagesContainer = ref(null)
 
-const toast = ref({
-  visible: false,
-  message: '',
-  color: 'success'
-})
+const channelFilters = [
+  { label: 'Todos', value: 'all' },
+  { label: 'WhatsApp', value: 'whatsapp' },
+  { label: 'Web', value: 'web' }
+]
 
+const SOURCE_ALIASES = { baileys: 'WhatsApp', cloud_api: 'WhatsApp', twilio: 'Twilio', web: 'Web', whatsapp: 'WhatsApp', meta: 'Meta' }
+const getSourceLabel = (source) => SOURCE_ALIASES[source] || source || '?'
+const getSourceColor = (source) => {
+  if (source === 'web') return 'primary'
+  if (['whatsapp', 'baileys', 'cloud_api'].includes(source)) return 'success'
+  return 'secondary'
+}
+const getInitial = (conv) => {
+  if (conv.name) return conv.name.charAt(0).toUpperCase()
+  if (conv.phone) return '#'
+  return '?'
+}
+
+const toast = ref({ visible: false, message: '', color: 'success' })
 const showToast = (message, color = 'success') => {
   toast.value = { visible: true, message, color }
 }
 
-const loadVenue = async () => {
-  try {
-    venue.value = await getVenueById(route.params.id)
-    if (venue.value?.name) {
-      breadcrumbStore.setTitle(`Chat ${venue.value.name}`)
-    }
-  } catch (error) {
-    console.error('Error loading venue:', error)
-    showToast('Error al cargar la cabaña', 'danger')
-  }
+// Relative time helper
+const relativeTime = (dateStr) => {
+  if (!dateStr) return ''
+  const d = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now - d
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 1) return 'ahora'
+  if (diffMin < 60) return `${diffMin}m`
+  const diffH = Math.floor(diffMin / 60)
+  if (diffH < 24) return `${diffH}h`
+  const diffD = Math.floor(diffH / 24)
+  if (diffD < 7) return `${diffD}d`
+  return d.toLocaleDateString('es-CO', { day: '2-digit', month: 'short' })
 }
 
-const loadProviders = async () => {
-  try {
-    const response = await fetch('/api/llm-providers', { credentials: 'include' })
-    if (response.ok) {
-      const allProviders = await response.json()
-      providers.value = allProviders.filter(p => p.is_active)
-      
-      const defaultProvider = providers.value.find(p => p.is_default)
-      if (defaultProvider) {
-        selectedProviderId.value = defaultProvider.id
-      } else if (providers.value.length > 0) {
-        selectedProviderId.value = providers.value[0].id
-      }
-    }
-  } catch (error) {
-    console.error('Error loading providers:', error)
-    showToast('Error al cargar proveedores LLM', 'danger')
-  }
+const formatTime = (dateStr) => {
+  if (!dateStr) return ''
+  return new Date(dateStr).toLocaleString('es-CO', { hour: '2-digit', minute: '2-digit' })
 }
 
 const scrollToBottom = async () => {
@@ -309,90 +281,28 @@ const scrollToBottom = async () => {
   }
 }
 
-const sendMessage = async () => {
-  if (!newMessage.value.trim() || !selectedProviderId.value || sending.value) return
-  
-  const userMessage = newMessage.value.trim()
-  messages.value.push({ id: null, role: 'user', content: userMessage })
-  newMessage.value = ''
-  sending.value = true
-  scrollToBottom()
-  
+// --- Data loading ---
+
+const loadVenue = async () => {
   try {
-    const response = await fetch(`/api/chat/${route.params.id}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({
-        message: userMessage,
-        provider_id: selectedProviderId.value,
-        conversation_id: conversationId.value,
-        contact_type: contactType.value,
-        contact_value: contactValue.value,
-        visitor_phone: contactType.value === 'whatsapp' && contactValue.value ? contactValue.value : undefined
-      })
-    })
-    
-    const result = await response.json()
-    
-    if (response.ok) {
-      // Store conversation_id from backend for subsequent messages
-      if (result.conversation_id) {
-        conversationId.value = result.conversation_id
-      }
-      // Track phone for send-to-whatsapp button
-      if (!activeConvPhone.value && contactType.value === 'whatsapp' && contactValue.value) {
-        activeConvPhone.value = contactValue.value
-      }
-      
-      // Update user message with ID from backend
-      if (result.user_message_id) {
-        const lastUserMsg = messages.value.findLast(m => m.role === 'user')
-        if (lastUserMsg) lastUserMsg.id = result.user_message_id
-      }
-
-      // Remove tool marker from displayed content if present
-      let displayContent = result.response || result.message || ''
-      displayContent = displayContent.replace(/\n<!-- \{.*?\} -->/g, '')
-
-      messages.value.push({
-        id: result.assistant_message_id || null,
-        role: 'assistant',
-        content: displayContent,
-        meta: {
-          model: result.model || 'Desconocido',
-          tokens: result.tokens || result.usage?.total_tokens
-        }
-      })
-      loadConversations()
-    } else {
-      showToast(result.error || 'Error al enviar mensaje', 'danger')
-      messages.value.pop()
+    venue.value = await getVenueById(venueId)
+    if (venue.value?.name) {
+      breadcrumbStore.setTitle(`Inbox ${venue.value.name}`)
     }
   } catch (error) {
-    console.error('Error sending message:', error)
-    showToast('Error al enviar mensaje', 'danger')
-    messages.value.pop()
-  } finally {
-    sending.value = false
-    scrollToBottom()
+    console.error('Error loading venue:', error)
   }
-}
-
-const clearConversation = () => {
-  messages.value = []
-  conversationId.value = null
-  activeConvSource.value = null
-  activeConvPhone.value = null
-  activeConvName.value = null
-  showToast('Conversación reiniciada')
-  loadConversations()
 }
 
 const loadConversations = async () => {
   loadingConversations.value = true
   try {
-    const response = await fetch(`/api/chat/${route.params.id}/conversations`, { credentials: 'include' })
+    const params = new URLSearchParams()
+    if (searchQuery.value) params.set('search', searchQuery.value)
+    if (activeChannelFilter.value === 'whatsapp') params.set('source', 'baileys,cloud_api,whatsapp')
+    else if (activeChannelFilter.value !== 'all') params.set('source', activeChannelFilter.value)
+
+    const response = await fetch(`/api/chat/${venueId}/conversations?${params}`, { credentials: 'include' })
     if (response.ok) {
       conversations.value = await response.json()
     }
@@ -403,346 +313,488 @@ const loadConversations = async () => {
   }
 }
 
-const resumeConversation = async (conv) => {
+const selectConversation = async (conv) => {
+  selectedConv.value = conv
+  loadingMessages.value = true
   try {
     const response = await fetch(`/api/chat/conversation/${conv.id}`, { credentials: 'include' })
     if (response.ok) {
       const data = await response.json()
-      conversationId.value = data.id
-      activeConvSource.value = data.source || null
-      activeConvPhone.value = data.phone || null
-      activeConvName.value = data.name || null
-      messages.value = data.messages.map(m => ({
-        id: m.id,
-        role: m.role,
-        content: (m.content || '').replace(/\n?<!-- \{.*?\} -->/g, ''),
-        media_url: m.media_url || null,
-        created_at: m.created_at || null,
-        status: m.status || null,
-        error_details: m.error_details || null,
-        meta: m.role === 'assistant' ? { model: m.model, tokens: m.tokens_used } : undefined
-      }))
+      messages.value = (data.messages || []).map(mapMessage)
+      // Clear unread badge locally
+      conv.unread_count = 0
     }
   } catch (error) {
-    console.error('Error resuming conversation:', error)
-    showToast('Error al cargar la conversación', 'danger')
+    console.error('Error loading messages:', error)
+    showToast('Error al cargar mensajes', 'danger')
+  } finally {
+    loadingMessages.value = false
+    scrollToBottom()
   }
 }
 
-const resumeBotForConversation = async (conv) => {
-  resumingConvId.value = conv.id
+const mapMessage = (m) => ({
+  id: m.id,
+  role: m.role,
+  content: (m.content || '').replace(/\n?<!-- \{.*?\} -->/g, ''),
+  media_url: m.media_url || null,
+  created_at: m.created_at || null,
+  status: m.status || null,
+  error_details: m.error_details || null,
+  provider: m.provider || null
+})
+
+const sendAdminReply = async () => {
+  if (!replyText.value.trim() || sendingReply.value || !selectedConv.value) return
+
+  const text = replyText.value.trim()
+  replyText.value = ''
+  sendingReply.value = true
+
   try {
-    const venueId = route.params.id
-    const response = await fetch(`/api/chat/${venueId}/conversations/${conv.id}/resume`, {
+    const response = await fetch(`/api/chat/${venueId}/conversations/${selectedConv.value.id}/admin-reply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ text })
+    })
+    const result = await response.json()
+    if (response.ok) {
+      messages.value.push(mapMessage(result))
+      scrollToBottom()
+      loadConversations()
+    } else {
+      showToast(result.error || 'Error al enviar', 'danger')
+      replyText.value = text // restore
+    }
+  } catch (error) {
+    console.error('Admin reply error:', error)
+    showToast('Error al enviar mensaje', 'danger')
+    replyText.value = text
+  } finally {
+    sendingReply.value = false
+  }
+}
+
+const resumeBot = async () => {
+  if (!selectedConv.value) return
+  resumingBot.value = true
+  try {
+    const response = await fetch(`/api/chat/${venueId}/conversations/${selectedConv.value.id}/resume`, {
       method: 'POST',
       credentials: 'include'
     })
     if (response.ok) {
-      conv.status = 'active'
-      showToast('Bot reanudado para esta conversación', 'success')
+      selectedConv.value.status = 'active'
+      showToast('Bot reanudado')
+      loadConversations()
     } else {
       const data = await response.json()
       showToast(data.error || 'Error al reanudar', 'danger')
     }
   } catch (error) {
-    console.error('Error resuming bot:', error)
     showToast('Error al reanudar el bot', 'danger')
   } finally {
-    resumingConvId.value = null
+    resumingBot.value = false
   }
 }
 
-const reprocessMessage = async (message) => {
-  reprocessingId.value = message.id
+const confirmDeleteConversation = () => {
+  if (!selectedConv.value) return
+  const name = selectedConv.value.name || selectedConv.value.phone || 'esta conversación'
+  if (!confirm(`¿Eliminar la conversación con ${name}? Se borrarán todos los mensajes.`)) return
+  deleteConversation()
+}
+
+const deleteConversation = async () => {
+  if (!selectedConv.value) return
+  deletingConv.value = true
   try {
-    const response = await fetch(`/api/chat/${route.params.id}/messages/${message.id}/reprocess`, {
-      method: 'POST',
+    const response = await fetch(`/api/chat/${venueId}/conversations/${selectedConv.value.id}`, {
+      method: 'DELETE',
       credentials: 'include'
     })
-    const result = await response.json()
     if (response.ok) {
-      let displayContent = result.response || ''
-      displayContent = displayContent.replace(/\n?<!-- \{.*?\} -->/g, '')
-      messages.value.push({
-        id: result.assistant_message_id,
-        role: 'assistant',
-        content: displayContent,
-        created_at: new Date().toISOString(),
-        status: result.status || null,
-        meta: { model: result.model, tokens: result.tokens_used }
-      })
-      showToast('Mensaje reprocesado exitosamente')
+      showToast('Conversación eliminada')
+      selectedConv.value = null
+      messages.value = []
+      loadConversations()
     } else {
-      showToast(result.error || 'Error al reprocesar', 'danger')
+      const data = await response.json()
+      showToast(data.error || 'Error al eliminar', 'danger')
     }
-  } catch {
-    showToast('Error al reprocesar el mensaje', 'danger')
+  } catch (error) {
+    showToast('Error al eliminar la conversación', 'danger')
   } finally {
-    reprocessingId.value = null
+    deletingConv.value = false
   }
 }
 
-const sendToWhatsApp = async (message) => {
-  sendingWaId.value = message.id
-  try {
-    const response = await fetch(`/api/chat/${route.params.id}/messages/${message.id}/send-whatsapp`, {
-      method: 'POST',
-      credentials: 'include'
-    })
-    const result = await response.json()
-    if (response.ok) {
-      message.status = result.status || 'sent'
-      showToast('Mensaje enviado por WhatsApp')
-    } else {
-      showToast(result.error || 'Error al enviar por WhatsApp', 'danger')
-    }
-  } catch {
-    showToast('Error al enviar por WhatsApp', 'danger')
-  } finally {
-    sendingWaId.value = null
-  }
+// Debounced search
+let searchTimeout = null
+const debouncedSearch = () => {
+  clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => loadConversations(), 300)
 }
 
-const formatDate = (dateStr) => {
-  return new Date(dateStr).toLocaleString('es-CO', {
-    day: '2-digit', month: 'short', year: 'numeric',
-    hour: '2-digit', minute: '2-digit'
-  })
+const setChannelFilter = (value) => {
+  activeChannelFilter.value = value
+  loadConversations()
 }
 
-const formatTime = (dateStr) => {
-  if (!dateStr) return ''
-  return new Date(dateStr).toLocaleString('es-CO', {
-    hour: '2-digit', minute: '2-digit'
-  })
-}
-
-// Alias para nombres de servicios (cambiar aquí si se quiere renombrar)
-const SOURCE_ALIASES = { baileys: 'Ave', twilio: 'Twilio', web: 'Web', whatsapp: 'WhatsApp', meta: 'Meta' }
-
-const getSourceLabel = (source) => SOURCE_ALIASES[source] || source
-
-const openImageModal = (url) => {
-  imageModalUrl.value = url
-}
-
-const getSourceColor = (source) => {
-  const colors = { web: 'primary', whatsapp: 'success', baileys: 'success', twilio: 'info', meta: 'dark' }
-  return colors[source] || 'secondary'
-}
-
-watch(messages, () => {
-  scrollToBottom()
-}, { deep: true })
-
-// Auto-refresh: poll conversations list and active conversation every 5 seconds
+// Polling
 let pollInterval = null
 
-const pollConversations = async () => {
+const pollData = async () => {
   loadConversations()
-  // If viewing a conversation, refresh its messages
-  if (conversationId.value && !sending.value) {
+  // Refresh active conversation messages
+  if (selectedConv.value && !sendingReply.value) {
     try {
-      const response = await fetch(`/api/chat/conversation/${conversationId.value}`, { credentials: 'include' })
+      const response = await fetch(`/api/chat/conversation/${selectedConv.value.id}`, { credentials: 'include' })
       if (response.ok) {
         const data = await response.json()
-        const newMessages = data.messages.map(m => ({
-          id: m.id,
-          role: m.role,
-          content: (m.content || '').replace(/\n?<!-- \{.*?\} -->/g, ''),
-          media_url: m.media_url || null,
-          created_at: m.created_at || null,
-          status: m.status || null,
-          error_details: m.error_details || null,
-          meta: m.role === 'assistant' ? { model: m.model, tokens: m.tokens_used } : undefined
-        }))
-        // Only update if message count changed (avoid flicker)
+        const newMessages = (data.messages || []).map(mapMessage)
         if (newMessages.length !== messages.value.length) {
           messages.value = newMessages
+          scrollToBottom()
         }
       }
-    } catch (e) { /* ignore polling errors */ }
+    } catch { /* ignore polling errors */ }
   }
 }
+
+watch(messages, () => scrollToBottom(), { deep: true })
 
 onMounted(async () => {
   loadVenue()
-  loadProviders()
   loadConversations()
 
+  // If arrived with conversation_id in query
   const qConversationId = route.query.conversation_id
-  const qEstimateId = route.query.estimate_id
-  if (qEstimateId) {
-    estimateId.value = qEstimateId
-  }
   if (qConversationId) {
-    arrivedWithConversation.value = true
-    await resumeConversation({ id: qConversationId })
+    await selectConversation({ id: qConversationId })
   }
 
-  pollInterval = setInterval(pollConversations, 5000)
+  pollInterval = setInterval(pollData, 5000)
 })
 
 onUnmounted(() => {
   if (pollInterval) clearInterval(pollInterval)
+  clearTimeout(searchTimeout)
 })
 </script>
 
 <style scoped>
-.contact-input-bar {
-  padding: 0.75rem 1rem;
-  background-color: #e9ecef;
-  border-bottom: 1px solid #dee2e6;
+.inbox-container {
+  display: flex;
+  height: calc(100vh - 120px);
+  min-height: 500px;
+  border: 1px solid var(--cui-border-color, #dee2e6);
+  border-radius: 0.375rem;
+  overflow: hidden;
+  background: var(--cui-body-bg, #fff);
 }
 
-.chat-container {
+/* --- LEFT PANEL --- */
+.inbox-sidebar {
   display: flex;
   flex-direction: column;
-  height: 450px;
+  width: 360px;
+  min-width: 280px;
+  border-right: 1px solid var(--cui-border-color, #dee2e6);
+  background: var(--cui-body-bg, #fff);
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--cui-border-color, #dee2e6);
+  background: var(--cui-tertiary-bg, #f8f9fa);
+}
+
+.sidebar-search {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--cui-border-color, #dee2e6);
+}
+
+.sidebar-filters {
+  display: flex;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--cui-border-color, #dee2e6);
+  gap: 0.25rem;
+}
+
+.filter-chip {
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: all 0.15s;
+}
+
+.sidebar-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.conv-item {
+  display: flex;
+  padding: 0.75rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--cui-border-color-translucent, rgba(0,0,0,0.05));
+  transition: background 0.15s;
+  gap: 0.75rem;
+}
+.conv-item:hover {
+  background: var(--cui-tertiary-bg, #f0f0f0);
+}
+.conv-item.active {
+  background: var(--cui-primary-bg-subtle, #e7f1ff);
+}
+
+.conv-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--cui-primary, #321fdb);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.conv-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.conv-top-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.conv-name {
+  font-weight: 600;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.conv-time {
+  font-size: 0.7rem;
+  color: var(--cui-body-color-secondary, #6c757d);
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+}
+
+.conv-bottom-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.conv-preview {
+  font-size: 0.8rem;
+  color: var(--cui-body-color-secondary, #6c757d);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.conv-badges {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+}
+
+.badge-unread {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #2eb85c;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  padding: 0 4px;
+}
+
+.badge-escalation {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #f9b115;
+  color: #000;
+  font-size: 0.65rem;
+  font-weight: 700;
+  width: 18px;
+  height: 18px;
+  border-radius: 9px;
+}
+
+.conv-source-row {
+  display: flex;
+}
+.conv-source-badge {
+  font-size: 0.65rem;
+}
+
+/* --- RIGHT PANEL --- */
+.inbox-chat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--cui-body-bg, #fff);
+}
+
+.chat-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--cui-border-color, #dee2e6);
+  background: var(--cui-tertiary-bg, #f8f9fa);
+}
+.chat-header-info {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.chat-header-actions {
+  flex-shrink: 0;
+}
+
+.btn-back {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  padding: 0;
+  cursor: pointer;
+  color: var(--cui-body-color, #333);
 }
 
 .chat-messages {
   flex: 1;
   overflow-y: auto;
   padding: 1rem;
-  background-color: #f8f9fa;
+  background: var(--cui-tertiary-bg, #f8f9fa);
 }
 
 .chat-input-container {
-  padding: 1rem;
-  border-top: 1px solid #dee2e6;
-  background-color: #fff;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--cui-border-color, #dee2e6);
+  background: var(--cui-body-bg, #fff);
 }
 
+/* --- Messages --- */
 .message-wrapper {
   display: flex;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 }
-
-.message-user {
-  justify-content: flex-end;
-}
-
-.message-assistant {
-  justify-content: flex-start;
-}
+.message-user { justify-content: flex-end; }
+.message-assistant { justify-content: flex-start; }
 
 .message-bubble {
-  max-width: 75%;
-  padding: 0.75rem 1rem;
-  border-radius: 1rem;
+  max-width: 70%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
   word-wrap: break-word;
 }
 
 .bubble-user {
   background-color: #321fdb;
   color: white;
-  border-bottom-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.2rem;
 }
-
 .bubble-assistant {
-  background-color: #fff;
-  color: #333;
-  border: 1px solid #dee2e6;
-  border-bottom-left-radius: 0.25rem;
+  background-color: var(--cui-body-bg, #fff);
+  color: var(--cui-body-color, #333);
+  border: 1px solid var(--cui-border-color, #dee2e6);
+  border-bottom-left-radius: 0.2rem;
 }
 
 .message-content {
   white-space: pre-wrap;
-}
-
-.message-meta {
-  margin-top: 0.5rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid rgba(0,0,0,0.1);
-}
-
-.chat-image {
-  max-width: 200px;
-  max-height: 200px;
-  border-radius: 0.5rem;
-  cursor: pointer;
-  object-fit: cover;
-  transition: opacity 0.2s;
-}
-.chat-image:hover {
-  opacity: 0.85;
+  font-size: 0.875rem;
 }
 
 .message-footer {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  margin-top: 0.25rem;
+  margin-top: 0.15rem;
   gap: 0.15rem;
 }
-
 .message-time {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   opacity: 0.7;
 }
+.bubble-user .message-time { color: rgba(255,255,255,0.7); }
+.message-status { font-size: 0.65rem; line-height: 1; }
+.status-read { color: #53bdeb; }
+.bubble-user .message-status { color: rgba(255,255,255,0.7); }
+.bubble-user .status-read { color: #a0d8ef; }
 
-.bubble-user .message-time {
-  color: rgba(255,255,255,0.7);
+.message-provider-badge {
+  font-size: 0.65rem;
+}
+.badge-admin {
+  background: #e8daef;
+  color: #6c3483;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+.badge-ai {
+  background: #d5f5e3;
+  color: #1e8449;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-weight: 600;
 }
 
-.message-status {
-  font-size: 0.7rem;
-  line-height: 1;
-}
-
-.status-read {
-  color: #53bdeb;
-}
-
-.bubble-user .message-status {
-  color: rgba(255,255,255,0.7);
-}
-.bubble-user .status-read {
-  color: #a0d8ef;
-}
-
-.btn-reprocess {
-  background: none;
-  border: none;
-  padding: 0 2px;
-  font-size: 0.75rem;
+.message-media { }
+.chat-image {
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: 0.5rem;
   cursor: pointer;
-  opacity: 0.5;
-  transition: opacity 0.2s;
-  color: inherit;
-  line-height: 1;
+  object-fit: cover;
 }
-.btn-reprocess:hover {
-  opacity: 1;
-}
-.btn-reprocess:disabled {
-  cursor: not-allowed;
-  opacity: 0.3;
-}
-.bubble-user .btn-reprocess {
-  color: rgba(255,255,255,0.7);
-}
-.bubble-user .btn-reprocess:hover {
-  color: white;
-}
+.chat-image:hover { opacity: 0.85; }
 
-.btn-send-wa {
-  background: none;
-  border: none;
-  padding: 0 2px;
-  font-size: 0.75rem;
-  cursor: pointer;
-  opacity: 0.5;
-  transition: opacity 0.2s;
-  color: inherit;
-  line-height: 1;
-}
-.btn-send-wa:hover {
-  opacity: 1;
-}
-.btn-send-wa:disabled {
-  cursor: not-allowed;
-  opacity: 0.3;
+/* --- Responsive mobile --- */
+@media (max-width: 767.98px) {
+  .inbox-container {
+    height: calc(100vh - 80px);
+  }
+  .inbox-sidebar {
+    width: 100%;
+    min-width: 0;
+    border-right: none;
+  }
+  .inbox-chat {
+    width: 100%;
+  }
 }
 </style>

--- a/src/views/venues/WhatsAppConnectionView.vue
+++ b/src/views/venues/WhatsAppConnectionView.vue
@@ -91,6 +91,100 @@
         </CCardBody>
       </CCard>
 
+      <!-- Cloud API Config (super_admin only) -->
+      <CCard v-if="isSuperAdmin" class="mb-4">
+        <CCardHeader>
+          <strong>Canal de WhatsApp</strong>
+        </CCardHeader>
+        <CCardBody>
+          <div class="mb-3">
+            <label class="form-label small fw-semibold">Canal</label>
+            <CFormSelect v-model="cloudConfig.channel" size="sm" @change="saveCloudConfig">
+              <option value="baileys">Baileys (QR / no oficial)</option>
+              <option value="cloud_api">Cloud API (Meta oficial)</option>
+            </CFormSelect>
+          </div>
+
+          <div v-if="cloudConfig.channel === 'cloud_api'">
+            <div class="mb-3">
+              <label class="form-label small fw-semibold">Phone Number ID</label>
+              <CFormInput
+                v-model="cloudConfig.meta_phone_number_id"
+                placeholder="Ej: 977827948755668"
+                size="sm"
+              />
+            </div>
+            <div class="mb-3">
+              <label class="form-label small fw-semibold">Access Token</label>
+              <CFormInput
+                v-model="cloudConfig.meta_access_token"
+                type="password"
+                placeholder="Token de acceso de Meta"
+                size="sm"
+              />
+            </div>
+            <div class="mb-3">
+              <label class="form-label small fw-semibold">Verify Token (webhook)</label>
+              <div class="d-flex gap-2">
+                <CFormInput
+                  v-model="cloudConfig.meta_verify_token"
+                  placeholder="Token de verificación"
+                  size="sm"
+                />
+                <CButton color="secondary" variant="outline" size="sm" @click="generateVerifyToken" style="white-space: nowrap;">
+                  Generar
+                </CButton>
+              </div>
+            </div>
+
+            <CAlert color="info" class="small py-2 mb-3">
+              <strong>Webhook URL:</strong><br />
+              <code>https://cabania.app/api/webhook/whatsapp</code><br />
+              Configura esta URL en Meta Developer Console &rarr; WhatsApp &rarr; Configuration.
+            </CAlert>
+
+            <div class="d-flex gap-2">
+              <CButton color="primary" size="sm" @click="saveCloudConfig" :disabled="savingCloud">
+                <CSpinner v-if="savingCloud" size="sm" class="me-1" />
+                Guardar
+              </CButton>
+              <CButton color="success" variant="outline" size="sm" @click="showTestModal = true" :disabled="!cloudConfig.meta_phone_number_id">
+                Enviar prueba
+              </CButton>
+            </div>
+
+            <CAlert v-if="cloudSaveMsg" :color="cloudSaveMsg.type" class="mt-3 small py-2">
+              {{ cloudSaveMsg.text }}
+            </CAlert>
+          </div>
+        </CCardBody>
+      </CCard>
+
+      <!-- Test Message Modal -->
+      <CModal :visible="showTestModal" @close="showTestModal = false" alignment="center">
+        <CModalHeader>
+          <CModalTitle>Enviar mensaje de prueba</CModalTitle>
+        </CModalHeader>
+        <CModalBody>
+          <p class="text-body-secondary small">
+            Se enviará el template <strong>hello_world</strong> al número indicado.
+            El número debe estar verificado en la app de Meta.
+          </p>
+          <CFormInput
+            v-model="testPhone"
+            placeholder="Número destino (ej: 573001234567)"
+            size="sm"
+          />
+        </CModalBody>
+        <CModalFooter>
+          <CButton color="secondary" variant="outline" size="sm" @click="showTestModal = false">Cancelar</CButton>
+          <CButton color="success" size="sm" @click="sendTestMessage" :disabled="!testPhone || sendingTest">
+            <CSpinner v-if="sendingTest" size="sm" class="me-1" />
+            Enviar
+          </CButton>
+        </CModalFooter>
+      </CModal>
+
       <!-- Excluded phones -->
       <CCard v-if="status === 'connected' || status === 'disconnected' || status === 'not_configured'" class="mb-4">
         <CCardHeader class="d-flex justify-content-between align-items-center">
@@ -331,12 +425,15 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { ref, onMounted, onUnmounted, watch, nextTick, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import QRCode from 'qrcode'
+import { useAuth } from '@/composables/useAuth'
 
 const route = useRoute()
 const venueId = route.params.id
+const { user } = useAuth()
+const isSuperAdmin = computed(() => user.value?.is_super_admin === true)
 
 const venueName = ref('')
 const loading = ref(true)
@@ -371,6 +468,19 @@ const escConfig = ref({
   auto_resume_hour: 3
 })
 const escSaveMsg = ref(null)
+
+// Cloud API config
+const cloudConfig = ref({
+  channel: 'baileys',
+  meta_phone_number_id: '',
+  meta_access_token: '',
+  meta_verify_token: ''
+})
+const savingCloud = ref(false)
+const cloudSaveMsg = ref(null)
+const showTestModal = ref(false)
+const testPhone = ref('')
+const sendingTest = ref(false)
 
 let pollInterval = null
 
@@ -567,6 +677,88 @@ async function saveEscalationConfig() {
   }
 }
 
+// Cloud API config
+async function fetchCloudConfig() {
+  try {
+    const res = await fetch(`/api/venues/${venueId}/whatsapp/cloud-config`, { credentials: 'include' })
+    if (res.ok) {
+      const data = await res.json()
+      cloudConfig.value = {
+        channel: data.channel || 'baileys',
+        meta_phone_number_id: data.meta_phone_number_id || '',
+        meta_access_token: data.has_token ? '••••••' : '',
+        meta_verify_token: data.meta_verify_token || ''
+      }
+      // If channel is cloud_api and connected, update status display
+      if (data.channel === 'cloud_api' && data.meta_phone_number_id && data.has_token) {
+        status.value = 'connected'
+        phoneNumber.value = data.meta_phone_number_id
+      }
+    }
+  } catch (err) {
+    console.error('[whatsapp-ui] Error fetching cloud config:', err)
+  }
+}
+
+async function saveCloudConfig() {
+  savingCloud.value = true
+  cloudSaveMsg.value = null
+  try {
+    const res = await fetch(`/api/venues/${venueId}/whatsapp/cloud-config`, {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(cloudConfig.value)
+    })
+    if (res.ok) {
+      cloudSaveMsg.value = { type: 'success', text: 'Configuración Cloud API guardada' }
+      // Refresh status
+      await fetchStatus()
+    } else {
+      const data = await res.json()
+      cloudSaveMsg.value = { type: 'danger', text: data.error || 'Error al guardar' }
+    }
+    setTimeout(() => { cloudSaveMsg.value = null }, 4000)
+  } catch (err) {
+    cloudSaveMsg.value = { type: 'danger', text: 'Error al guardar' }
+    setTimeout(() => { cloudSaveMsg.value = null }, 4000)
+  } finally {
+    savingCloud.value = false
+  }
+}
+
+function generateVerifyToken() {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  let token = ''
+  for (let i = 0; i < 32; i++) token += chars.charAt(Math.floor(Math.random() * chars.length))
+  cloudConfig.value.meta_verify_token = token
+}
+
+async function sendTestMessage() {
+  sendingTest.value = true
+  try {
+    const res = await fetch(`/api/venues/${venueId}/whatsapp/cloud-test`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ to: testPhone.value.replace(/\D/g, '') })
+    })
+    const data = await res.json()
+    if (res.ok) {
+      cloudSaveMsg.value = { type: 'success', text: `Mensaje de prueba enviado (ID: ${data.message_id})` }
+      showTestModal.value = false
+    } else {
+      cloudSaveMsg.value = { type: 'danger', text: data.error || 'Error al enviar' }
+    }
+    setTimeout(() => { cloudSaveMsg.value = null }, 5000)
+  } catch (err) {
+    cloudSaveMsg.value = { type: 'danger', text: 'Error al enviar mensaje de prueba' }
+    setTimeout(() => { cloudSaveMsg.value = null }, 5000)
+  } finally {
+    sendingTest.value = false
+  }
+}
+
 async function fetchStats() {
   loadingStats.value = true
   try {
@@ -649,6 +841,7 @@ onMounted(async () => {
   await fetchStatus()
   await fetchExcludedPhones()
   await fetchEscalationConfig()
+  if (isSuperAdmin.value) fetchCloudConfig()
   fetchStats()
   fetchEvents()
   // Start polling if QR pending


### PR DESCRIPTION
## Summary
- Add Meta WhatsApp Cloud API as an alternative channel to Baileys (unofficial)
- Super admins can configure each venue to use `baileys` or `cloud_api` channel
- Global webhook (`/api/webhook/whatsapp`) receives messages from Meta and routes by `phone_number_id` to the correct venue
- All existing `whatsappClient.sendMessage` calls replaced with channel-aware helpers (`sendWhatsAppReply`, `sendWhatsAppImage`)

## Changes
- **`server/services/metaWhatsApp.js`** (new) — Graph API v22.0 client: sendText, sendImage, sendTemplate, downloadMedia, markAsRead
- **`server/prisma/schema.prisma`** — 4 new columns on `whatsapp_connections`: channel, meta_phone_number_id, meta_access_token, meta_verify_token
- **`server/index.js`** — Webhook endpoints, Cloud API config endpoints, send helpers, channel-aware routing
- **`src/views/venues/WhatsAppConnectionView.vue`** — Channel selector + Cloud API config UI + test message (super_admin only)

## New env var required
- `META_WEBHOOK_VERIFY_TOKEN` — shared token for Meta webhook verification

## Test plan
- [ ] Add `META_WEBHOOK_VERIFY_TOKEN` to Vercel env vars
- [ ] Deploy and verify webhook verification at `https://cabania.app/api/webhook/whatsapp`
- [ ] Configure Cloud API for a venue via super_admin UI
- [ ] Send test template message from UI
- [ ] Send WhatsApp message to the business number and verify AI responds
- [ ] Verify delivery/read status updates flow through
- [ ] Verify Baileys venues still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)