### PR TITLE
feat: User impersonation for admin support

### DIFF
--- a/server/auth/replitAuth.js
+++ b/server/auth/replitAuth.js
@@ -327,12 +327,83 @@ async function setupAuth(app) {
         where: { user_id: userId },
       });
 
+      // Impersonation info
+      const isImpersonating = !!req.session.originalUserId;
+      let impersonationInfo = null;
+      if (isImpersonating) {
+        const originalUser = await prisma.users.findUnique({
+          where: { id: req.session.originalUserId },
+          select: { id: true, email: true, display_name: true }
+        });
+        impersonationInfo = { originalUser };
+      }
+
       // Exclude password_hash from response
       const { password_hash, ...userData } = user;
-      res.json({ ...userData, permissionDetails, subscription, has_passkeys: passkeyCount > 0, passkey_count: passkeyCount });
+      res.json({ ...userData, permissionDetails, subscription, has_passkeys: passkeyCount > 0, passkey_count: passkeyCount, is_impersonating: isImpersonating, impersonation: impersonationInfo });
     } catch (error) {
       console.error('Error fetching user:', error);
       res.status(500).json({ message: 'Failed to fetch user' });
+    }
+  });
+
+  // --- Impersonation routes ---
+
+  app.post('/api/auth/impersonate', isAuthenticated, async (req, res) => {
+    try {
+      const { getUserPermissions, hasPermission } = require('./permissions');
+      const currentUserId = String(req.user.claims.sub);
+      const originalUserId = req.session.originalUserId || currentUserId;
+
+      // Check permission on the ORIGINAL user (not the impersonated one)
+      const originalPerms = await getUserPermissions(originalUserId);
+      if (!hasPermission(originalPerms, 'users:impersonate')) {
+        return res.status(403).json({ error: 'No tiene permiso para impersonar usuarios' });
+      }
+
+      const { targetUserId } = req.body;
+      if (!targetUserId) {
+        return res.status(400).json({ error: 'targetUserId requerido' });
+      }
+
+      const targetUser = await prisma.users.findUnique({ where: { id: targetUserId } });
+      if (!targetUser) {
+        return res.status(404).json({ error: 'Usuario no encontrado' });
+      }
+
+      // Store original user and switch session
+      req.session.originalUserId = originalUserId;
+      req.user.claims.sub = targetUserId;
+      req.session.passport.user = { claims: { sub: targetUserId }, expires_at: req.user.expires_at };
+
+      req.session.save((err) => {
+        if (err) return res.status(500).json({ error: 'Error al guardar sesión' });
+        res.json({ message: 'Impersonando usuario', targetUser: { id: targetUser.id, email: targetUser.email, display_name: targetUser.display_name } });
+      });
+    } catch (error) {
+      console.error('Error impersonating:', error);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  app.post('/api/auth/stop-impersonating', isAuthenticated, async (req, res) => {
+    try {
+      const originalUserId = req.session.originalUserId;
+      if (!originalUserId) {
+        return res.status(400).json({ error: 'No está impersonando a nadie' });
+      }
+
+      req.user.claims.sub = originalUserId;
+      req.session.passport.user = { claims: { sub: originalUserId }, expires_at: req.user.expires_at };
+      delete req.session.originalUserId;
+
+      req.session.save((err) => {
+        if (err) return res.status(500).json({ error: 'Error al guardar sesión' });
+        res.json({ message: 'Sesión restaurada' });
+      });
+    } catch (error) {
+      console.error('Error stopping impersonation:', error);
+      res.status(500).json({ error: error.message });
     }
   });
 

--- a/server/scripts/seeds/permissions.js
+++ b/server/scripts/seeds/permissions.js
@@ -37,6 +37,7 @@ const data = [
   { code: 'venues:edit', name: 'Editar venues', description: 'Permite editar venues' },
   { code: 'venues:view', name: 'Ver venues', description: 'Permite ver venues de organizaciones asignadas' },
   { code: 'ai-usage:view', name: 'Ver uso de IA', description: 'Permite ver estadísticas y registros de uso de IA' },
+  { code: 'users:impersonate', name: 'Impersonar usuarios', description: 'Permite iniciar sesión como otro usuario para soporte/debugging' },
   // Permisos :own — solo aplican a datos creados por el usuario
   { code: 'accommodations:view:own', name: 'Ver reservas propias', description: 'Ve ocupación general sin detalles; solo detalles de reservas propias' },
   { code: 'accommodations:edit:own', name: 'Editar reservas propias', description: 'Solo puede editar reservas que creó' },

--- a/src/components/ImpersonationBanner.vue
+++ b/src/components/ImpersonationBanner.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed } from 'vue'
+import { useAuth } from '@/composables/useAuth'
+
+const { user, stopImpersonating } = useAuth()
+
+const isImpersonating = computed(() => user.value?.is_impersonating)
+const originalUser = computed(() => user.value?.impersonation?.originalUser)
+const currentName = computed(() => user.value?.display_name || user.value?.email || 'usuario')
+
+async function handleStop() {
+  await stopImpersonating()
+  window.location.reload()
+}
+</script>
+
+<template>
+  <div v-if="isImpersonating" class="impersonation-banner d-flex align-items-center justify-content-center gap-2 px-3 py-2">
+    <CIcon icon="cil-user" />
+    <span>
+      Impersonando a <strong>{{ currentName }}</strong>
+      <template v-if="originalUser"> &mdash; sesion original: {{ originalUser.display_name || originalUser.email }}</template>
+    </span>
+    <CButton color="light" size="sm" class="ms-2" @click="handleStop">
+      Volver a mi cuenta
+    </CButton>
+  </div>
+</template>
+
+<style scoped>
+.impersonation-banner {
+  background-color: #e55353;
+  color: white;
+  font-size: 0.875rem;
+  z-index: 1030;
+}
+</style>

--- a/src/components/users/UserTable.vue
+++ b/src/components/users/UserTable.vue
@@ -59,6 +59,13 @@
               </CBadge>
             </CTableDataCell>
             <CTableDataCell>
+              <CButton
+                v-if="canImpersonate(user)"
+                color="info"
+                size="sm"
+                class="me-2"
+                @click="onImpersonate(user)"
+              >Impersonar</CButton>
               <CButton color="primary" size="sm" @click="onEdit(user)">Editar</CButton>
               <CButton
                 v-if="user.is_locked"
@@ -108,6 +115,9 @@ import { ref, onMounted, computed, watch } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { CIcon } from '@coreui/icons-vue'
 import { fetchUsers, deleteUser, lockUser, unlockUser } from '@/services/userService'
+import { useAuth } from '@/composables/useAuth'
+
+const { user: currentUser, impersonate } = useAuth()
 
 const users = ref([])
 const searchQuery = ref('')
@@ -210,6 +220,24 @@ async function loadUsers() {
 onMounted(() => {
   loadUsers()
 })
+
+function canImpersonate(u) {
+  if (!currentUser.value) return false
+  if (u.id === currentUser.value.id) return false
+  return currentUser.value.is_super_admin ||
+    currentUser.value.profile?.permissions?.includes('users:impersonate')
+}
+
+async function onImpersonate(u) {
+  if (confirm(`¿Impersonar a "${u.display_name || u.email}"? Verás la app como si fueras ese usuario.`)) {
+    const success = await impersonate(u.id)
+    if (success) {
+      window.location.reload()
+    } else {
+      alert('Error al impersonar usuario')
+    }
+  }
+}
 
 function onEdit(user) {
   router.push(`/users/${user.id}/edit`)

--- a/src/composables/useAuth.js
+++ b/src/composables/useAuth.js
@@ -221,6 +221,46 @@ async function deletePasskey(id) {
   }
 }
 
+async function impersonate(targetUserId) {
+  try {
+    error.value = null;
+    const response = await fetch('/api/auth/impersonate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ targetUserId }),
+    });
+    if (!response.ok) {
+      const data = await response.json();
+      throw new Error(data.error || 'Error al impersonar usuario');
+    }
+    await fetchUser();
+    return true;
+  } catch (err) {
+    error.value = err.message;
+    return false;
+  }
+}
+
+async function stopImpersonating() {
+  try {
+    error.value = null;
+    const response = await fetch('/api/auth/stop-impersonating', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      const data = await response.json();
+      throw new Error(data.error || 'Error al restaurar sesión');
+    }
+    await fetchUser();
+    return true;
+  } catch (err) {
+    error.value = err.message;
+    return false;
+  }
+}
+
 async function requestLoginCode(email) {
   try {
     error.value = null;
@@ -288,6 +328,8 @@ export function useAuth() {
     deletePasskey,
     requestLoginCode,
     verifyLoginCode,
+    impersonate,
+    stopImpersonating,
   };
 }
 

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -3,6 +3,7 @@ import { CContainer } from '@coreui/vue'
 import AppFooter from '@/components/AppFooter.vue'
 import AppHeader from '@/components/AppHeader.vue'
 import AppSidebar from '@/components/AppSidebar.vue'
+import ImpersonationBanner from '@/components/ImpersonationBanner.vue'
 import TrialBanner from '@/components/TrialBanner.vue'
 import PasskeyBanner from '@/components/PasskeyBanner.vue'
 </script>
@@ -11,6 +12,7 @@ import PasskeyBanner from '@/components/PasskeyBanner.vue'
   <div>
     <AppSidebar />
     <div class="wrapper d-flex flex-column min-vh-100">
+      <ImpersonationBanner />
       <TrialBanner />
       <PasskeyBanner />
       <AppHeader />


### PR DESCRIPTION
## Summary
- Add `users:impersonate` permission and seed
- Backend endpoints: `POST /api/auth/impersonate` and `POST /api/auth/stop-impersonating`
- `/api/auth/user` now returns `is_impersonating` and `impersonation.originalUser`
- Impersonation banner (red bar) with "Volver a mi cuenta" button
- "Impersonar" button in UserTable (visible to super admins or users with permission)

## Test plan
- [ ] Login as admin, go to Users, verify "Impersonar" button appears
- [ ] Click Impersonar on a user, verify red banner appears
- [ ] Navigate app as impersonated user, verify correct data/permissions
- [ ] Click "Volver a mi cuenta", verify session restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)