### PR TITLE
feat: Balance refund and evidence for claimed deposits

### DIFF
--- a/src/views/accommodations/AccommodationDetailView.vue
+++ b/src/views/accommodations/AccommodationDetailView.vue
@@ -334,6 +334,33 @@
                   </CCol>
                 </CRow>
 
+                <template v-if="deposit.status === 'claimed' && deposit.refund_amount">
+                  <CRow class="mt-3">
+                    <CCol :md="4">
+                      <h6 class="text-muted mb-1">Monto Devuelto</h6>
+                      <p class="fw-bold text-success mb-0">{{ formatCurrency(deposit.refund_amount) }}</p>
+                    </CCol>
+                    <CCol :md="4">
+                      <h6 class="text-muted mb-1">Fecha de Devolución</h6>
+                      <p class="mb-0">{{ formatPaymentDate(deposit.refund_date) }}</p>
+                    </CCol>
+                    <CCol :md="4" v-if="deposit.refund_reference">
+                      <h6 class="text-muted mb-1">Referencia Devolución</h6>
+                      <p class="mb-0">{{ deposit.refund_reference }}</p>
+                    </CCol>
+                  </CRow>
+                </template>
+
+                <CAlert v-if="deposit.status === 'claimed' && depositPendingBalance > 0 && !deposit.refund_amount" color="warning" class="mt-3 d-flex justify-content-between align-items-center">
+                  <div>
+                    <strong>Saldo pendiente de devolver:</strong> {{ formatCurrency(depositPendingBalance) }}
+                    <div class="small text-muted">Depósito {{ formatCurrency(deposit.amount) }} − Retención {{ formatCurrency(deposit.damage_amount) }}</div>
+                  </div>
+                  <CButton color="success" size="sm" @click="openRefundBalanceModal">
+                    Devolver Saldo
+                  </CButton>
+                </CAlert>
+
                 <div class="mt-3 d-flex gap-2" v-if="deposit.status === 'pending'">
                   <CButton color="success" size="sm" @click="openRefundModal">
                     Liberar Depósito
@@ -478,17 +505,38 @@
       </div>
       <div class="mb-3">
         <label class="form-label">Comprobante de Devolución</label>
-        <div class="d-flex gap-2 mb-2">
-          <CButton color="primary" size="sm" @click="$refs.refundFileInput?.click()">
-            <CIcon name="cil-folder-open" class="me-1" /> Seleccionar archivo
-          </CButton>
-          <CButton color="info" size="sm" @click="$refs.refundCameraInput?.click()">
-            <CIcon name="cil-camera" class="me-1" /> Tomar Foto
-          </CButton>
+        <div
+          class="receipt-upload-area"
+          :class="{ 'is-dragging': refundDragging }"
+          @paste="handleRefundPaste"
+          @drop.prevent="handleRefundDrop"
+          @dragover.prevent="refundDragging = true"
+          @dragleave="refundDragging = false"
+          @click="$refs.refundFileInput?.click()"
+          tabindex="0"
+        >
+          <div v-if="refundFile" class="text-center">
+            <CIcon name="cil-check-circle" class="text-success me-1" />
+            {{ refundFile.name || 'Imagen seleccionada' }}
+          </div>
+          <div v-else class="text-center">
+            <CIcon name="cil-cloud-upload" size="xl" class="mb-2 text-secondary" />
+            <div class="mb-2">Arrastrar imagen aquí o Ctrl+V para pegar</div>
+            <div class="d-flex justify-content-center gap-2 flex-wrap">
+              <CButton color="primary" size="sm" @click.stop="$refs.refundFileInput?.click()">
+                <CIcon name="cil-folder-open" class="me-1" /> Seleccionar archivo
+              </CButton>
+              <CButton color="info" size="sm" @click.stop="$refs.refundCameraInput?.click()">
+                <CIcon name="cil-camera" class="me-1" /> Tomar Foto
+              </CButton>
+              <CButton color="secondary" size="sm" @click.stop="pasteRefundFromClipboard">
+                <CIcon name="cil-clipboard" class="me-1" /> Pegar
+              </CButton>
+            </div>
+          </div>
         </div>
         <input ref="refundFileInput" type="file" accept="image/*" class="d-none" @change="handleRefundFile" />
         <input ref="refundCameraInput" type="file" accept="image/*" capture="environment" class="d-none" @change="handleRefundFile" />
-        <div class="small text-muted">Adjunta el comprobante de la transferencia</div>
       </div>
     </CModalBody>
     <CModalFooter>
@@ -1003,9 +1051,24 @@ async function confirmDeleteDeposit() {
   }
 }
 
+const depositPendingBalance = computed(() => {
+  if (!deposit.value || deposit.value.status !== 'claimed') return 0
+  return (parseFloat(deposit.value.amount) || 0) - (parseFloat(deposit.value.damage_amount) || 0)
+})
+
 function openRefundModal() {
   refundForm.value = {
     refund_amount: deposit.value?.amount || '',
+    refund_date: new Date().toISOString().split('T')[0],
+    refund_reference: ''
+  }
+  refundFile.value = null
+  showRefundModal.value = true
+}
+
+function openRefundBalanceModal() {
+  refundForm.value = {
+    refund_amount: depositPendingBalance.value,
     refund_date: new Date().toISOString().split('T')[0],
     refund_reference: ''
   }
@@ -1022,8 +1085,46 @@ function openClaimModal() {
   showClaimModal.value = true
 }
 
+const refundDragging = ref(false)
+
 function handleRefundFile(event) {
   refundFile.value = event.target.files[0] || null
+}
+
+function handleRefundDrop(e) {
+  refundDragging.value = false
+  const file = e.dataTransfer?.files?.[0]
+  if (file && file.type.startsWith('image/')) {
+    refundFile.value = file
+  }
+}
+
+function handleRefundPaste(e) {
+  const items = e.clipboardData?.items
+  if (!items) return
+  for (const item of items) {
+    if (item.type.startsWith('image/')) {
+      refundFile.value = item.getAsFile()
+      break
+    }
+  }
+}
+
+async function pasteRefundFromClipboard() {
+  try {
+    const clipboardItems = await navigator.clipboard.read()
+    for (const clipboardItem of clipboardItems) {
+      for (const type of clipboardItem.types) {
+        if (type.startsWith('image/')) {
+          const blob = await clipboardItem.getType(type)
+          refundFile.value = new File([blob], 'pasted-image.png', { type })
+          return
+        }
+      }
+    }
+  } catch (error) {
+    console.error('Error reading clipboard:', error)
+  }
 }
 
 function handleClaimFile(event) {
@@ -1148,3 +1249,24 @@ onMounted(() => {
   loadExpenses()
 })
 </script>
+
+<style scoped>
+.receipt-upload-area {
+  border: 2px dashed #ccc;
+  border-radius: 8px;
+  padding: 20px;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.receipt-upload-area:hover,
+.receipt-upload-area:focus {
+  border-color: #321fdb;
+  background-color: #f8f9fa;
+}
+
+.receipt-upload-area.is-dragging {
+  border-color: #321fdb;
+  background-color: #e7f1ff;
+}
+</style>

--- a/src/views/deposits/DepositDetailView.vue
+++ b/src/views/deposits/DepositDetailView.vue
@@ -117,6 +117,38 @@
                 <p>{{ deposit.damage_notes || '—' }}</p>
               </CCol>
             </CRow>
+
+            <template v-if="deposit.refund_amount">
+              <hr class="my-4" />
+              <h5 class="mb-3">Devolución de Saldo</h5>
+              <CRow>
+                <CCol :md="4">
+                  <h6 class="text-muted">Monto Devuelto</h6>
+                  <p class="fs-5 fw-bold text-success">{{ formatCurrency(deposit.refund_amount) }}</p>
+                </CCol>
+                <CCol :md="4">
+                  <h6 class="text-muted">Fecha de Devolución</h6>
+                  <p>{{ formatDate(deposit.refund_date) }}</p>
+                </CCol>
+                <CCol :md="4">
+                  <h6 class="text-muted">Referencia de Devolución</h6>
+                  <p>{{ deposit.refund_reference || '—' }}</p>
+                </CCol>
+              </CRow>
+            </template>
+
+            <template v-if="pendingBalance > 0 && !deposit.refund_amount">
+              <CAlert color="warning" class="mt-3 d-flex justify-content-between align-items-center">
+                <div>
+                  <strong>Saldo pendiente de devolver:</strong> {{ formatCurrency(pendingBalance) }}
+                  <div class="small text-muted">Depósito {{ formatCurrency(deposit.amount) }} − Daños {{ formatCurrency(deposit.damage_amount) }}</div>
+                </div>
+                <CButton color="success" size="sm" @click="openRefundBalanceModal">
+                  <CIcon :icon="cilArrowCircleLeft" class="me-1" />
+                  Devolver Saldo
+                </CButton>
+              </CAlert>
+            </template>
           </template>
 
           <hr class="my-4" />
@@ -140,7 +172,7 @@
                   </CBadge>
                   <small v-if="item.description" class="d-block mt-1 text-muted">{{ item.description }}</small>
                 </div>
-                <div v-if="deposit.status === 'pending'" class="card-footer p-1">
+                <div v-if="deposit.status === 'pending' || (deposit.status === 'claimed' && !deposit.refund_amount)" class="card-footer p-1">
                   <CButton 
                     color="danger" 
                     size="sm" 
@@ -158,7 +190,7 @@
             No hay evidencia registrada
           </div>
 
-          <template v-if="deposit.status === 'pending'">
+          <template v-if="deposit.status === 'pending' || (deposit.status === 'claimed' && !deposit.refund_amount)">
             <div class="mb-4 p-3 border rounded bg-light">
               <h6 class="mb-3">Agregar Evidencia</h6>
               <CRow class="mb-2">
@@ -224,7 +256,7 @@
 
             <hr class="my-4" />
 
-            <div class="d-flex gap-2 flex-wrap">
+            <div v-if="deposit.status === 'pending'" class="d-flex gap-2 flex-wrap">
               <CButton color="success" @click="showRefundModal = true">
                 <CIcon :icon="cilArrowCircleLeft" class="me-1" />
                 Devolver Depósito
@@ -343,7 +375,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { CIcon } from '@coreui/icons-vue'
 import { cilTrash, cilCloudUpload, cilArrowCircleLeft, cilWarning, cilFolderOpen, cilClipboard, cilCamera } from '@coreui/icons'
@@ -367,6 +399,18 @@ const uploading = ref(false)
 const uploadError = ref('')
 const newEvidenceType = ref('damage')
 const newEvidenceDescription = ref('')
+
+const pendingBalance = computed(() => {
+  if (!deposit.value || deposit.value.status !== 'claimed') return 0
+  return (deposit.value.amount || 0) - (deposit.value.damage_amount || 0)
+})
+
+const openRefundBalanceModal = () => {
+  refundForm.value.refund_amount = pendingBalance.value
+  refundForm.value.refund_date = new Date().toISOString().split('T')[0]
+  refundForm.value.refund_reference = ''
+  showRefundModal.value = true
+}
 
 const refundForm = ref({
   refund_amount: '',


### PR DESCRIPTION
## Summary
- Allow recording balance refund on deposits already claimed for damages (status stays 'claimed')
- Show pending balance alert with "Devolver Saldo" button when `amount - damage_amount > 0`
- Enable evidence upload (photos/invoices) on claimed deposits until refund is recorded
- Display refund details (amount, date, reference) once recorded

## Test plan
- [ ] Open a deposit with status 'claimed' and partial damages
- [ ] Verify pending balance alert shows correct amount
- [ ] Upload evidence photo on claimed deposit
- [ ] Click "Devolver Saldo", confirm modal pre-fills with pending balance
- [ ] After refund, verify both damage and refund sections display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)